### PR TITLE
Add an extension for when a user requests a deployment

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -675,6 +675,9 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 		}
 
 		// Initiate the deployment
+		// The extension point should pass in: Project, Environment, SelectRelease, buildName
+		$this->extend('doDeploy', $project, $environment, $buildName, $data);
+
 		$sha = $project->DNBuildList()->byName($buildName);
 		$deployment = DNDeployment::create();
 		$deployment->EnvironmentID = $environment->ID;


### PR DESCRIPTION
There is a decision of whether to put this before or after the permissions check.
I opted for after, since of the potential security implications.
A safe default saves peoples lives.
