### PR TITLE
Add validation for using an environment named "test"

### DIFF
--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -810,6 +810,12 @@ class DNEnvironment extends DataObject {
 	 */
 	public function onBeforeWrite() {
 		parent::onBeforeWrite();
+
+		if (strtoupper(trim($this->Name)) == "TEST") {
+			throw new Exception("Test is not a valid environment name when using Capistrano backend.");
+		}
+
+
 		if($this->Name && $this->Name.'.rb' != $this->Filename) {
 			$this->Filename = $this->Name.'.rb';
 		}


### PR DESCRIPTION
This currently breaks Capistrano, for which test is a reserved word.
If Capistrano backend is modularized, this should be moved there.
