### PR TITLE
Refactor configuration of DNData

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,4 +1,7 @@
 <?php
+
+Deprecation::notification_version('1.1.0', 'deploynaut');
+
 // *.sspak is required for data archives
 $exts = Config::inst()->get('File', 'allowed_extensions');
 $exts[] = 'sspak';

--- a/_config/dnroot.yml
+++ b/_config/dnroot.yml
@@ -1,30 +1,16 @@
 ---
 Name: deploynaut
-Only:
-    environment: dev
 ---
 Injector:
-    DeploymentBackend:
-        class: CapistranoDeploymentBackend
-    DNData:
-        constructor:
-            0: "../deploynaut-resources/envs"
-            1: "../deploynaut-resources/gitkeys"
-            2: "assets/transfers"
-DNEnvironment:
-    allow_web_editing: false
----
-Name: deploynaut
-Only:
-    environment: live
----
-Injector:
-    DeploymentBackend:
-        class: CapistranoDeploymentBackend
-    DNData:
-        constructor:
-            0: "../../deploynaut-resources/envs"
-            1: "../../deploynaut-resources/gitkeys"
-            2: "../assets/transfers"
-DNEnvironment:
-    allow_web_editing: false
+  DeploymentBackend:
+    class: CapistranoDeploymentBackend
+  DNData:
+    properties:
+      Backend: '%$DeploymentBackend'
+      # Set EnvironmentDir and KeyDir to absolute paths in your live project
+      EnvironmentDir: "../deploynaut-resources/envs"
+      KeyDir: "../deploynaut-resources/gitkeys"
+      # Set to an absolute path, or a relative path to append to BASE_PATH
+      DataTransferDir: "assets/transfers"
+      # User to run commands as locally
+      GitUser: ''

--- a/code/backends/CapistranoDeploymentBackend.php
+++ b/code/backends/CapistranoDeploymentBackend.php
@@ -146,7 +146,7 @@ class CapistranoDeploymentBackend implements DeploymentBackend {
 			}
 		}
 
-		$data = Injector::inst()->get('DNData');
+		$data = DNData::inst();
 		// Generate a capfile from a template
 		$capTemplate = file_get_contents(BASE_PATH.'/deploynaut/Capfile.template');
 		$cap = str_replace(

--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -600,7 +600,7 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	 * @return DNData
 	 */
 	public function DNData() {
-		return Injector::inst()->get('DNData');
+		return DNData::inst();
 	}
 
 	/**

--- a/code/jobs/CloneGitRepo.php
+++ b/code/jobs/CloneGitRepo.php
@@ -26,7 +26,7 @@ class CloneGitRepo {
 		}
 
 		// if an alternate user has been configured for clone, run the command as that user
-		$user = Injector::inst()->get('DNData')->getGitUser();
+		$user = DNData::inst()->getGitUser();
 
 		if(file_exists($path)) {
 			if($user) {

--- a/code/jobs/DataTransferJob.php
+++ b/code/jobs/DataTransferJob.php
@@ -108,6 +108,6 @@ class DataTransferJob {
 	 * @return DNData
 	 */
 	protected function DNData() {
-		return Injector::inst()->get('DNData');
+		return DNData::inst();
 	}
 }

--- a/code/jobs/DeployJob.php
+++ b/code/jobs/DeployJob.php
@@ -71,6 +71,6 @@ class DeployJob {
 	 * @return DNData
 	 */
 	protected function DNData() {
-		return Injector::inst()->get('DNData');
+		return DNData::inst();
 	}
 }

--- a/code/jobs/FetchJob.php
+++ b/code/jobs/FetchJob.php
@@ -30,7 +30,7 @@ class FetchJob {
 		// @todo Gitonomy doesn't seem to have any way to prefix the command properly, if you
 		// set 'sudo -u composer git' as the "command" parameter, it tries to run the whole
 		// thing as a single command and fails
-		$user = Injector::inst()->get('DNData')->getGitUser();
+		$user = DNData::inst()->getGitUser();
 		if($user) {
 			$command = sprintf('cd %s && sudo -u %s git fetch -p origin +refs/heads/*:refs/heads/* --tags', $path, $user);
 			$process = new \Symfony\Component\Process\Process($command);

--- a/code/jobs/PingJob.php
+++ b/code/jobs/PingJob.php
@@ -27,7 +27,7 @@ class PingJob {
 	 * @return DNData
 	 */
 	public function DNData() {
-		return Injector::inst()->get('DNData');
+		return DNData::inst();
 	}
 
 	/**

--- a/code/model/DNDataArchive.php
+++ b/code/model/DNDataArchive.php
@@ -280,8 +280,7 @@ class DNDataArchive extends DataObject {
 	 * @return String Absolute file path
 	 */
 	public function generateFilepath(DNDataTransfer $dataTransfer) {
-		$filepath = null;
-		$data = Injector::inst()->get('DNData');
+		$data = DNData::inst();
 		$transferDir = $data->getDataTransferDir();
 		$sanitizeRegex = array('/\s+/', '/[^a-zA-Z0-9-_\.]/');
 		$sanitizeReplace = array('/_/', '');

--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -466,7 +466,7 @@ class DNEnvironment extends DataObject {
 	 * @return DNData
 	 */
 	public function DNData() {
-		return Injector::inst()->get('DNData');
+		return DNData::inst();
 	}
 
 	/**

--- a/code/model/DNProject.php
+++ b/code/model/DNProject.php
@@ -258,7 +258,7 @@ class DNProject extends DataObject {
 	 * @return DNData
 	 */
 	public function DNData() {
-		return Injector::inst()->get('DNData');
+		return DNData::inst();
 	}
 
 	/**

--- a/code/tasks/SyncProjectsAndEnvironments.php
+++ b/code/tasks/SyncProjectsAndEnvironments.php
@@ -23,7 +23,7 @@ class SyncProjectsAndEnvironments extends BuildTask {
 			sleep(3);
 		}
 		
-		$data = Injector::inst()->get('DNData');
+		$data = DNData::inst();
 		$projectPaths = $data->getProjectPaths();
 
 		// Sync projects

--- a/tests/DeploynautTest.php
+++ b/tests/DeploynautTest.php
@@ -16,12 +16,15 @@ abstract class DeploynautTest extends SapphireTest {
 	protected function setTemporaryPath($path) {
 		$this->envPath = $path;
 		Filesystem::makeFolder($this->envPath);
+		$this->envPath = realpath($this->envPath);
 		Injector::inst()->load(array(
 			'DNData' => array(
-				'constructor' => array(
-					0 => $this->envPath,
-					1 => TEMP_FOLDER .'/deploynaut_test/gitkeys',
-					2 => Director::baseFolder() . '/assets/transfers'
+				'properties' => array(
+					'Backend' => '%$DeploymentBackend',
+					'EnvironmentDir' => $this->envPath,
+					'KeyDir' => TEMP_FOLDER .'/deploynaut_test/gitkeys',
+					'DataTransferDir' => Director::baseFolder() . '/assets/transfers',
+					'GitUser' => ''
 				)
 			)
 		));


### PR DESCRIPTION
This strips out the live / dev conditional configs out of DNData, and also replaces the constructor ordered parameters to DNData so that configs make more sense and are easier to override. This also allows these fields to be configured via `mysite/_config.php` if necessary. (e.g. `DNData::inst()->setDataTransferDir(DATA_TRANSFER_DIR);`)

Some instructions have been added to the default config.yml on how to configure these paths best in your live project.

This also resolves a critical issue where data transfers failed due to the data transfer directory having the `../assets` value appended to `BASE_PATH`, which is not where the site assets are actually stored.

`realpath` has been used to help resolve complicated relative paths and make logging more robust.
