### PR TITLE
API Ensure that flush and dev/build are performed correctly on multi-node instances

### DIFF
--- a/ruby/deploy.rb
+++ b/ruby/deploy.rb
@@ -31,10 +31,12 @@ namespace :deploy do
 		# We allow users to not use sake at all if they set the path to false
 		if (sake_path != false)
 			if exists?(:webserver_user)
-				run "sudo -u #{webserver_user} bash #{latest_release}/#{sake_path} dev/build flush=1", :roles => :db
+				run "sudo -u #{webserver_user} bash #{latest_release}/#{sake_path} dev flush=1", :roles => :db
+				run "sudo -u #{webserver_user} bash #{latest_release}/#{sake_path} dev/build", :roles => :db, :once => true
 			else
 				run "mkdir -p #{latest_release}/silverstripe-cache", :roles => :db
-				run "bash #{latest_release}/#{sake_path} dev/build flush=1", :roles => :db
+				run "bash #{latest_release}/#{sake_path} dev flush=1", :roles => :db
+				run "bash #{latest_release}/#{sake_path} dev/build", :roles => :db, :once => true
 				run "rm -rf #{latest_release}/silverstripe-cache", :roles => :db
 			end
 		end


### PR DESCRIPTION
In environments (such as a 3-node cluster) DB operations should not be performed on all nodes simultaneously. This fix uses :once to limit this to one server, but ensures that all servers are still adequately flushed.

This fix was made a while back in a development branch in the old deploynaut repo but wasn't finished.
