### PR TITLE
API Better logging of curl errors during smoketesting

### DIFF
--- a/code/model/steps/SmokeTestPipelineStep.php
+++ b/code/model/steps/SmokeTestPipelineStep.php
@@ -109,6 +109,12 @@ class SmokeTestPipelineStep extends PipelineStep {
 			}
 
 			$contents = curl_exec($ch);
+			if(curl_errno($ch)) {
+				$this->log(sprintf('Curl error: %s', curl_error($ch)));
+				$failed = true;
+				continue;
+			}
+
 			$info =	curl_getinfo($ch);
 
 			// if an expected response time is specified, check that against the results

--- a/tests/SmokeTestPipelineStepTest.php
+++ b/tests/SmokeTestPipelineStepTest.php
@@ -43,7 +43,7 @@ class SmokeTestPipelineStepTest extends PipelineTest {
 		$step = $this->getDummySmokeTestStep('FailTest');
 		$this->assertFalse($step->start());
 		$this->assertHasLog('Starting smoke test "BrokenPage" to URL http://bob.bob.bob.bob/');
-		$this->assertHasLog('Smoke test "BrokenPage" to URL http://bob.bob.bob.bob/ failed');
+		$this->assertHasLog('Curl error: ');
 		$this->assertHasLog('Starting smoke test "Home" to URL https://github.com/');
 		$this->assertHasLog('Smoke test "Home" to URL https://github.com/ successful');
 		$this->assertEquals('Failed', $step->Status);


### PR DESCRIPTION
So that instead of getting errors like "HTTP code 0 doesn't match expected 200" we can see the actual error.
