### PR TITLE
BUG Fix sspak path substitution when deploynaut is installed in a symlinked directory

### DIFF
--- a/code/backends/CapistranoDeploymentBackend.php
+++ b/code/backends/CapistranoDeploymentBackend.php
@@ -260,7 +260,11 @@ class CapistranoDeploymentBackend implements DeploymentBackend {
 
 		// HACK: find_or_make() expects path relative to assets/
 		$sspakFilepath = ltrim(
-			str_replace(ASSETS_PATH, '', $filepathBase . DIRECTORY_SEPARATOR . $sspakFilename),
+			str_replace(
+				array(ASSETS_PATH, realpath(ASSETS_PATH)),
+				'',
+				$filepathBase . DIRECTORY_SEPARATOR . $sspakFilename
+			),
 			DIRECTORY_SEPARATOR
 		);
 


### PR DESCRIPTION
In some cases ASSETS_PATH will not be the same as realpath(ASSETS_PATH) and substitutions to generate a data transfers directory relative to assets will fail.
