### PR TITLE
API Allow group-based permissions to be applied

### DIFF
--- a/code/model/DNDataArchive.php
+++ b/code/model/DNDataArchive.php
@@ -228,7 +228,8 @@ class DNDataArchive extends DataObject {
 
 		// Hooks into ArchiveUploaders permission to prevent proliferation of permission checkboxes.
 		// Bypasses the quota check - we don't need to check for it as long as we move the snapshot within the project.
-		return (bool)($targetEnv->ArchiveUploaders()->byID($member->ID));
+		return $targetEnv->ArchiveUploaders()->byID($member->ID)
+			|| $member->inGroups($targetEnv->ArchiveUploaderGroups());
 	}
 
 	/**

--- a/code/model/DNProject.php
+++ b/code/model/DNProject.php
@@ -175,10 +175,7 @@ class DNProject extends DataObject {
 
 		if(Permission::checkMember($member, 'ADMIN')) return true;
 
-		foreach($this->Viewers() as $group) {
-			if($group->Members()->byID($member->ID)) return true;
-		}
-		return false;
+		return $member->inGroups($this->Viewers());
 	}
 
 	public function canRestore($member = null) {
@@ -364,8 +361,9 @@ class DNProject extends DataObject {
 		$workspaceField->setDescription('This is where the GIT repository are located on this server');
 		$fields->insertAfter($workspaceField, 'CVSPath');
 
-		$readAccessGroups = new CheckboxSetField("Viewers", "Project viewers", Group::get()->map());
-		$readAccessGroups->setDescription('These groups can view the project in the front-end.');
+		$readAccessGroups = ListboxField::create('Viewers', 'Project viewers', Group::get()->map()->toArray())
+			->setMultiple(true)
+			->setDescription('These groups can view the project in the front-end.');
 		$fields->addFieldToTab("Root.Main", $readAccessGroups);
 
 		$this->setCreateProjectFolderField($fields);

--- a/javascript/environment.js
+++ b/javascript/environment.js
@@ -4,17 +4,65 @@
 	$.entwine.warningLevel = $.entwine.WARN_LEVEL_BESTPRACTISE;
 	$.entwine('ss.deploynaut', function($) {
 		
-		$('#Form_ItemEditForm_TickAllSnapshot input').entwine({
-			onclick: function(evt) {
-				var id = $(evt.target).attr('value');
-				var checked = evt.target.checked;
-				$('#Form_ItemEditForm_CanRestoreMembers_' + id)[0].checked = checked;
-				$('#Form_ItemEditForm_CanBackupMembers_' + id)[0].checked = checked;
-				$('#Form_ItemEditForm_ArchiveDeleters_' + id)[0].checked = checked;
-				$('#Form_ItemEditForm_ArchiveUploaders_' + id)[0].checked = checked;
-				$('#Form_ItemEditForm_ArchiveDownloaders_' + id)[0].checked = checked;
-				$('#Form_ItemEditForm_PipelineApprovers_' + id)[0].checked = checked;
-				$('#Form_ItemEditForm_PipelineCancellers_' + id)[0].checked = checked;
+		$('.tickall select').entwine({
+			IDs: [],
+			targets: function() {
+				return [];
+			},
+			onchange: function() {
+				var 
+					oldVal = this.getIDs() || [],
+					newVal = this.val() || [],
+					targets = this.targets();
+				// Update each list
+				$.each(targets, function(targetIndex, target) {
+					var targetFiltered = target.val() || [];
+					// Deselect removed items
+					targetFiltered = $.grep(targetFiltered, function(targetItem) {
+						var keep = !($.inArray(targetItem, oldVal) > -1) // Wasn't in old list, could not have been removed
+							|| ($.inArray(targetItem, newVal) > -1); // Either added or already selected
+						return keep;
+					});
+					
+					// Select newly added items
+					$.each(newVal, function(newItemIndex, newItem) {
+						if(!($.inArray(newItem, targetFiltered) > -1) && !($.inArray(newItem, oldVal) > -1)) {
+							targetFiltered.push(newItem);
+						}
+					});
+					// Update item
+					target
+						.val(targetFiltered)
+						.trigger('liszt:updated')
+						.trigger('change')
+						.chosen();
+				});
+				// Update list
+				this.setIDs(newVal);
+			}
+		});
+		
+		$('.tickall select#Form_ItemEditForm_TickAllSnapshotGroups').entwine({
+			targets: function() {
+				return [
+					$('#Form_ItemEditForm_CanRestoreGroups'),
+					$('#Form_ItemEditForm_CanBackupGroups'),
+					$('#Form_ItemEditForm_ArchiveDeleterGroups'),
+					$('#Form_ItemEditForm_ArchiveUploaderGroups'),
+					$('#Form_ItemEditForm_ArchiveDownloaderGroups')
+				];
+			}
+		});
+		
+		$('.tickall select#Form_ItemEditForm_TickAllSnapshot').entwine({
+			targets: function() {
+				return [
+					$('#Form_ItemEditForm_CanRestoreMembers'),
+					$('#Form_ItemEditForm_CanBackupMembers'),
+					$('#Form_ItemEditForm_ArchiveDeleters'),
+					$('#Form_ItemEditForm_ArchiveUploaders'),
+					$('#Form_ItemEditForm_ArchiveDownloaders')
+				];
 			}
 		});
 

--- a/tests/DNEnvironmentTest.php
+++ b/tests/DNEnvironmentTest.php
@@ -4,35 +4,90 @@
  */
 class DNEnvironmentTest extends DeploynautTest {
 
-	/**
-	 *
-	 * @var DNEnvironment
-	 */
-	protected $env = null;
+	protected static $fixture_file = 'DNEnvironmentTest.yml';
 
 	/**
-	 *
-	 * @var DNProject
+	 * @return DNEnvironment
 	 */
-	protected $project = null;
-
-	public function setUp() {
-		parent::setUp();
-
-		// Create mock objects
-		$this->env = DNEnvironment::create();
-		$this->env->Name = 'uat';
-		$this->env->write();
-		$this->project = $this->env->Project();
-		$this->project->Name = 'testproject';
-		$this->project->write();
+	protected function getEnvironment() {
+		return $this->objFromFixture('DNEnvironment', 'uat');
 	}
 
 	/**
 	 *
 	 */
 	public function testGetConfigFilename() {
+		$environment = $this->getEnvironment();
 		$expected = $this->envPath.'/testproject/uat.rb';
-		$this->assertEquals($expected, $this->env->getConfigFilename());
+		$this->assertEquals($expected, $environment->getConfigFilename());
+	}
+
+	public function testPermissions() {
+		$environment = $this->getEnvironment();
+
+		// Check deployer / restorer permissions
+		$deployer = $this->objFromFixture('Member', 'deployer');
+		$deployerbygroup = $this->objFromFixture('Member', 'deployerbygroup');
+		$restorer = $this->objFromFixture('Member', 'restorer');
+		$restorerbygroup = $this->objFromFixture('Member', 'restorerbygroup');
+
+		$this->assertTrue($environment->canDeploy($deployer));
+		$this->assertTrue($environment->canDeploy($deployerbygroup));
+		$this->assertFalse($environment->canDeploy($restorer));
+		$this->assertFalse($environment->canDeploy($restorerbygroup));
+
+		$this->assertFalse($environment->canRestore($deployer));
+		$this->assertFalse($environment->canRestore($deployerbygroup));
+		$this->assertTrue($environment->canRestore($restorer));
+		$this->assertTrue($environment->canRestore($restorerbygroup));
+
+		// Check backup / uploader permissions
+		$backup = $this->objFromFixture('Member', 'backup');
+		$backupbygroup = $this->objFromFixture('Member', 'backupbygroup');
+		$uploader = $this->objFromFixture('Member', 'uploader');
+		$uploaderbygroup = $this->objFromFixture('Member', 'uploaderbygroup');
+
+		$this->assertTrue($environment->canBackup($backup));
+		$this->assertTrue($environment->canBackup($backupbygroup));
+		$this->assertFalse($environment->canBackup($uploader));
+		$this->assertFalse($environment->canBackup($uploaderbygroup));
+
+		$this->assertFalse($environment->canUploadArchive($backup));
+		$this->assertFalse($environment->canUploadArchive($backupbygroup));
+		$this->assertTrue($environment->canUploadArchive($uploader));
+		$this->assertTrue($environment->canUploadArchive($uploaderbygroup));
+
+		// Check downloader / deleters permissions
+		$downloader = $this->objFromFixture('Member', 'downloader');
+		$downloaderbygroup = $this->objFromFixture('Member', 'downloaderbygroup');
+		$deleter = $this->objFromFixture('Member', 'deleter');
+		$deleterbygroup = $this->objFromFixture('Member', 'deleterbygroup');
+
+		$this->assertTrue($environment->canDownloadArchive($downloader));
+		$this->assertTrue($environment->canDownloadArchive($downloaderbygroup));
+		$this->assertFalse($environment->canDownloadArchive($deleter));
+		$this->assertFalse($environment->canDownloadArchive($deleterbygroup));
+
+		$this->assertFalse($environment->canDeleteArchive($downloader));
+		$this->assertFalse($environment->canDeleteArchive($downloaderbygroup));
+		$this->assertTrue($environment->canDeleteArchive($deleter));
+		$this->assertTrue($environment->canDeleteArchive($deleterbygroup));
+
+		// Pipeline permissions
+		$approver = $this->objFromFixture('Member', 'approver');
+		$approverbygroup = $this->objFromFixture('Member', 'approverbygroup');
+		$canceller = $this->objFromFixture('Member', 'canceller');
+		$cancellerbygroup = $this->objFromFixture('Member', 'cancellerbygroup');
+
+		$this->assertTrue($environment->canApprove($approver));
+		$this->assertTrue($environment->canApprove($approverbygroup));
+		$this->assertFalse($environment->canApprove($canceller));
+		$this->assertFalse($environment->canApprove($cancellerbygroup));
+
+		$this->assertFalse($environment->canAbort($approver));
+		$this->assertFalse($environment->canAbort($approverbygroup));
+		$this->assertTrue($environment->canAbort($canceller));
+		$this->assertTrue($environment->canAbort($cancellerbygroup));
+
 	}
 }

--- a/tests/DNEnvironmentTest.yml
+++ b/tests/DNEnvironmentTest.yml
@@ -1,0 +1,81 @@
+Member:
+  deployer:
+    Email: deployer@example.com
+  deployerbygroup:
+    Email: deployer2@example.com
+  restorer:
+    Email: restorer@example.com
+  restorerbygroup:
+    Email: restorer2@example.com
+  backup:
+    Email: backup@example.com
+  backupbygroup:
+    Email: backup2@example.com
+  uploader:
+    Email: uploader@example.com
+  uploaderbygroup:
+    Email: uploader2@example.com
+  downloader:
+    Email: downloader@example.com
+  downloaderbygroup:
+    Email: downloader2@example.com
+  deleter:
+    Email: deleter@example.com
+  deleterbygroup:
+    Email: deleter2@example.com
+  approver:
+    Email: approver@example.com
+  approverbygroup:
+    Email: approver2@example.com
+  canceller:
+    Email: canceller@example.com
+  cancellerbygroup:
+    Email: canceller2@example.com
+Group:
+  deployer:
+    Title: deployers
+    Members: =>Member.deployerbygroup
+  restorer:
+    Title: restorers
+    Members: =>Member.restorerbygroup
+  backup:
+    Title: backup
+    Members: =>Member.backupbygroup
+  uploader:
+    Title: uploaders
+    Members: =>Member.uploaderbygroup
+  downloader:
+    Title: downloader
+    Members: =>Member.downloaderbygroup
+  deleter:
+    Title: deleters
+    Members: =>Member.deleterbygroup
+  approver:
+    Title: approver
+    Members: =>Member.approverbygroup
+  canceller:
+    Title: cancellers
+    Members: =>Member.cancellerbygroup
+DNProject:
+  testproject:
+    Name: 'testproject'
+DNEnvironment:
+  uat:
+    Name: uat
+    Project: =>DNProject.testproject
+    Deployers: =>Member.deployer
+    DeployerGroups: =>Group.deployer
+    CanRestoreMembers: =>Member.restorer
+    CanRestoreGroups: =>Group.restorer
+    CanBackupMembers: =>Member.backup
+    CanBackupGroups: =>Group.backup
+    ArchiveUploaders: =>Member.uploader
+    ArchiveUploaderGroups: =>Group.uploader
+    ArchiveDownloaders: =>Member.downloader
+    ArchiveDownloaderGroups: =>Group.downloader
+    ArchiveDeleters: =>Member.deleter
+    ArchiveDeleterGroups: =>Group.deleter
+    PipelineApprovers: =>Member.approver
+    PipelineApproverGroups: =>Group.approver
+    PipelineCancellers: =>Member.canceller
+    PipelineCancellerGroups: =>Group.canceller


### PR DESCRIPTION
This update means that group-based permissions can be applied instead of having to assign permissions on a per-user basis.

This can be useful in a site with many users, or where user-roles are not immediately identifiable from username, or where permissions are more appropriate to manage via groups.

This also replaces the many-checkbox based interface with the chosen-multiselect field.

![image](https://cloud.githubusercontent.com/assets/936064/4453511/e753da4a-485d-11e4-8637-afac4cdb815e.png)
