### PR TITLE
Adding specific permissions for viewers for DNEnvironment.

### DIFF
--- a/code/model/DNProject.php
+++ b/code/model/DNProject.php
@@ -300,7 +300,12 @@ class DNProject extends DataObject {
 	 * Provides a DNEnvironmentList of environments found in this project.
 	 */
 	public function DNEnvironmentList() {
-		return DNEnvironment::get()->filter('ProjectID', $this->ID)->setProjectID($this->ID);
+		return DNEnvironment::get()
+			->filter('ProjectID', $this->ID)
+			->setProjectID($this->ID)
+			->filterByCallBack(function($item) {
+				return $item->canView();
+			});
 	}
 
 	/**

--- a/tests/DNEnvironmentTest.php
+++ b/tests/DNEnvironmentTest.php
@@ -26,10 +26,19 @@ class DNEnvironmentTest extends DeploynautTest {
 		$environment = $this->getEnvironment();
 
 		// Check deployer / restorer permissions
+		$viewer = $this->objFromFixture('Member', 'viewer');
+		$viewerbygroup = $this->objFromFixture('Member', 'viewerbygroup');
 		$deployer = $this->objFromFixture('Member', 'deployer');
 		$deployerbygroup = $this->objFromFixture('Member', 'deployerbygroup');
 		$restorer = $this->objFromFixture('Member', 'restorer');
 		$restorerbygroup = $this->objFromFixture('Member', 'restorerbygroup');
+
+		$random = new Member(array('Email' => 'random@example.com'));
+		$random->write();
+
+		$this->assertFalse($environment->canView($random));
+		$this->assertTrue($environment->canView($viewer));
+		$this->assertTrue($environment->canView($viewerbygroup));
 
 		$this->assertTrue($environment->canDeploy($deployer));
 		$this->assertTrue($environment->canDeploy($deployerbygroup));
@@ -88,6 +97,17 @@ class DNEnvironmentTest extends DeploynautTest {
 		$this->assertFalse($environment->canAbort($approverbygroup));
 		$this->assertTrue($environment->canAbort($canceller));
 		$this->assertTrue($environment->canAbort($cancellerbygroup));
-
 	}
+
+	public function testViewerPermissionInheritedFromProjectIfNotConfigured() {
+		$environment = $this->objFromFixture('DNEnvironment', 'dev');
+		$viewerbygroup = $this->objFromFixture('Member', 'viewerbygroup');
+
+		$random = new Member(array('Email' => 'random@example.com'));
+		$random->write();
+
+		$this->assertFalse($environment->canView($random));
+		$this->assertTrue($environment->canView($viewerbygroup));
+	}
+
 }

--- a/tests/DNEnvironmentTest.yml
+++ b/tests/DNEnvironmentTest.yml
@@ -1,4 +1,8 @@
 Member:
+  viewer:
+    Email: viewer@example.com
+  viewerbygroup:
+    Email: viewer2@example.com
   deployer:
     Email: deployer@example.com
   deployerbygroup:
@@ -32,6 +36,9 @@ Member:
   cancellerbygroup:
     Email: canceller2@example.com
 Group:
+  viewer:
+    Title: Viewers
+    Members: =>Member.viewerbygroup
   deployer:
     Title: deployers
     Members: =>Member.deployerbygroup
@@ -59,10 +66,13 @@ Group:
 DNProject:
   testproject:
     Name: 'testproject'
+    Viewers: =>Group.viewer
 DNEnvironment:
   uat:
     Name: uat
     Project: =>DNProject.testproject
+    Viewers: =>Member.viewer
+    ViewerGroups: =>Group.viewer
     Deployers: =>Member.deployer
     DeployerGroups: =>Group.deployer
     CanRestoreMembers: =>Member.restorer
@@ -79,3 +89,6 @@ DNEnvironment:
     PipelineApproverGroups: =>Group.approver
     PipelineCancellers: =>Member.canceller
     PipelineCancellerGroups: =>Group.canceller
+  dev:
+    Name: dev
+    Project: =>DNProject.testproject


### PR DESCRIPTION
Allows setting of a viewer group or specific viewer users for a
deployment environment. This is useful for locking off certain
environments from being viewable (e.g. only certain users can see some
hidden environments)

If no viewers have been set for the environment, it falls back to
project view permissions.
