### PR TITLE
API Update messaging

### DIFF
--- a/_config/pipeline.yml
+++ b/_config/pipeline.yml
@@ -7,7 +7,7 @@ Pipeline:
       FilteredCommits: "DNFinishedCommits"
       Messages:
         Success: 'Deployment for <project>/<environment> has successfully completed'
-        Failure: 'Deployment for <project>/<environment> has failed'
+        Failure: 'Deployment for <project>/<environment> has failed. See <pipelinelink>'
         Abort: 'Deployment for <project>/<environment> has been aborted'
         RollbackStarted: 'Deployment failed, rollback for <project>/<environment> has begun.'
         RollbackSuccess: 'Rollback for <project>/<environment> has successfully completed.'
@@ -43,7 +43,7 @@ UserConfirmationStep:
       # Messages only sent to requester
       Request-Requester: 'You requested approval for deployment of <project>/<environment>. Cancel? <abortlink>'
       # Messages only sent to specified recipients
-      Request-Recipient: 'Deployment for <project>/<environment> requested by <requester>. Approve? <approvelink>'
+      Request-Recipient: 'Deployment for <project>/<environment> requested by <requester>. Login to approve at <approvelink>'
     Subjects:
       # Subject line for all users
       Cancel: 'Deployment for <project>/<environment>: Cancelled'

--- a/code/model/steps/EmergencyRollbackStep.php
+++ b/code/model/steps/EmergencyRollbackStep.php
@@ -131,6 +131,8 @@ class EmergencyRollbackStep extends LongRunningPipelineStep {
 		$this->log(_t('EmergencyRollbackStep.BEGINROLLBACKWINDOW',
 			"{$this->Title} is beginning a rollback window..."));
 		$this->write();
+		// Message author that the deployment is complete
+		$this->Pipeline()->sendMessage(Pipeline::ALERT_SUCCESS);
 		return true;
 	}
 

--- a/code/model/steps/PipelineStep.php
+++ b/code/model/steps/PipelineStep.php
@@ -48,7 +48,7 @@ class PipelineStep extends DataObject {
 		'Status',
 		'LastEdited'
 	);
-
+	
 	/**
 	 * Cached of config merged with defaults
 	 *
@@ -136,11 +136,16 @@ class PipelineStep extends DataObject {
 		$this->write();
 	}
 
-	public function markFailed() {
+	/**
+	 * Fail this pipeline step
+	 *
+	 * @param bool $notify Set to false to disable notifications for this failure
+	 */
+	public function markFailed($notify = true) {
 		$this->Status = 'Failed';
 		$this->log('Marking pipeline step as failed. See earlier log messages to determine cause.');
 		$this->write();
-		$this->Pipeline()->markFailed();
+		$this->Pipeline()->markFailed($notify);
 	}
 
 	/**

--- a/code/model/steps/RollbackStep.php
+++ b/code/model/steps/RollbackStep.php
@@ -82,6 +82,7 @@ class RollbackStep extends LongRunningPipelineStep {
 		$deployment->LeaveMaintenacePage = $this->doRestoreDB();
 		$deployment->EnvironmentID = $pipeline->EnvironmentID;
 		$deployment->SHA = $previous->SHA;
+		$deployment->DeployerID = $pipeline->AuthorID;
 		$deployment->write();
 		$deployment->start();
 		$this->RollbackDeploymentID = $deployment->ID;

--- a/code/model/steps/SmokeTestPipelineStep.php
+++ b/code/model/steps/SmokeTestPipelineStep.php
@@ -169,13 +169,13 @@ class SmokeTestPipelineStep extends PipelineStep {
 		}
 	}
 
-	public function markFailed() {
+	public function markFailed($notify = true) {
 		// Put up maintenance page after this fails
 		$this->log("Smoke testing failed: Putting up emergency maintenance page");
 		$this->Pipeline()->Environment()->enableMaintenace($this->Pipeline()->getLogger());
 
 		// Mark pipeline and step failed
-		parent::markFailed();
+		parent::markFailed($notify);
 	}
 
 }

--- a/code/model/steps/UserConfirmationStep.php
+++ b/code/model/steps/UserConfirmationStep.php
@@ -122,13 +122,6 @@ class UserConfirmationStep extends LongRunningPipelineStep {
 		return $this->messagingService;
 	}
 	
-	public function __isset($property) {
-		// Workaround fixed in https://github.com/silverstripe/silverstripe-framework/pull/3201
-		// Remove this once we update to a version of framework which supports this
-		if($property === 'MessagingService') return !empty($this->messagingService);
-		return parent::__isset($property);
-	}
-	
 	/**
 	 * Determine if the confirmation has been responded to (ether with acceptance, rejection, or cancelled)
 	 * 
@@ -218,7 +211,7 @@ class UserConfirmationStep extends LongRunningPipelineStep {
 		$this->Approval = 'Rejected';
 		$this->log("{$this->Title} has been rejected");
 		$this->ResponderID = Member::currentUserID();
-		$this->markFailed();
+		$this->markFailed(false);
 		$this->sendMessage(self::ALERT_REJECT);
 		return true;
 	}

--- a/tests/EmergencyRollbackStepTest.php
+++ b/tests/EmergencyRollbackStepTest.php
@@ -114,6 +114,9 @@ class EmergencyRollbackStepTest extends PipelineTest {
 
 		$this->logInWithPermission('APPLY_ROLES');
 		$this->assertTrue($step->beginRollbackWindow());
+
+		// Check that the message is sent
+		$this->assertSentMessage('Deployment for testproject/uat has successfully completed', 'test@example.com');
 	}
 
 	public function testRunningConfiguration() {
@@ -131,5 +134,8 @@ class EmergencyRollbackStepTest extends PipelineTest {
 		$step->Status = 'Failed';
 
 		$this->assertFalse($step->start());
+
+		// Check that the message is sent
+		$this->assertNotSentMessage('Deployment for testproject/uat has successfully completed', 'test@example.com');
 	}
 }

--- a/tests/UserConfirmationStepTest.php
+++ b/tests/UserConfirmationStepTest.php
@@ -161,6 +161,9 @@ class UserConfirmationStepTest extends PipelineTest {
 		$this->assertEquals('Failed', $step->Status);
 		$this->assertEquals('Rejected', $step->Approval);
 		$this->assertHasLog('TestConfirmStep has been rejected');
+		$this->assertNotSentMessage('Deployment for testproject/uat has failed', 'test@example.com');
+		$this->assertNotSentMessage('Deployment for testproject/uat has failed', 'abort@example.com');
+		$this->assertNotSentMessage('Deployment for testproject/uat has failed', 'errors@example.com');
 		$this->assertSentMessage('Deployment for testproject/uat has been rejected', 'test@example.com');
 		$this->assertSentMessage('Deployment for testproject/uat has been rejected', 'admin@example.com');
 	}


### PR DESCRIPTION
- Added `<pipelinelink>` so that messages can direct users to the log, and have added it to the error message.
- Added `<commitsha>` so that messages can distinguish which commit is being made.
- Improved wording on user confirmation message, so that it's made apparent that you need to login to provide approvals.
- Emergency rollback step will message the success message when it starts, rather than waiting for the timeout to occur. This means that once the deployment has actually complete and rollback is ready, the initiator is notified straight away.
- Fixed rollback step so that the initiator is set as the author.
- Removed a temporary hack which is no longer necessary.
