### PR TITLE
Improve information available on pipeline progress page

### DIFF
--- a/code/model/steps/PipelineStep.php
+++ b/code/model/steps/PipelineStep.php
@@ -70,13 +70,14 @@ class PipelineStep extends DataObject {
 	}
 
 	public function getNiceName() {
-		$NiceName = $this->getConfigSetting('NiceName') ?: $this->getTitle();
+		$niceName = $this->getConfigSetting('NiceName')
+			?: ucwords(trim(strtolower(preg_replace('/_?([A-Z])/', ' $1', $this->getTitle()))));
 		
 		if($this->isFinished()) {
-			$NiceName = $this->getConfigSetting('NiceDone') ?: $NiceName;
+			$niceName = $this->getConfigSetting('NiceDone') ?: $niceName;
 		}
 
-		return $NiceName;
+		return $niceName;
 	}
 
 	/**

--- a/css/deploynaut.css
+++ b/css/deploynaut.css
@@ -407,3 +407,6 @@ form.fields-wide .field label.left {
 	font-weight: bold;
 	opacity: 1.0;
 }
+.running-description {
+	clear: both;
+}

--- a/templates/Includes/PipelineStatus.ss
+++ b/templates/Includes/PipelineStatus.ss
@@ -1,0 +1,56 @@
+<h3 class="pull-left">Current Deployment</h3>
+
+<div class="btn-toolbar pull-right" id="deployprogress-actions">
+	<% if $canAbort %>
+	<div class="btn-group">
+		<a href="$Link('abort')" id="deployprogress-abort" class="btn btn-warning btn-small"
+		 onclick="return confirm('Are you sure you wish to abort this pipeline?');">
+			Abort Pipeline
+		</a>
+	</div>
+	<% end_if %>
+
+	<div class="btn-group">
+		<a class="btn" href="$Link">View Logs</a>
+		<button class="btn dropdown-toggle" data-toggle="dropdown">
+			<span class="caret"></span>
+		</button>
+		<ul class="dropdown-menu">
+			<% loop $LogOptions %>
+				<li><a href="$Link">$ButtonText</a></li>
+			<% end_loop %>
+		</ul>
+	</div>
+</div>
+
+<% if $RunningDescription %>
+	<p class="alert alert-info running-description">$RunningDescription</p>
+<% end_if %>
+
+<%-- Deployment progress bar --%>
+<%-- This doesn't currently allow for FrontendSteps after the NonFrontendSteps --%>
+<% uncached %>
+<div class="row" id="deployprogress">
+	<% loop $Steps %>
+	<div class="span3 deployprogress-step <% if $isRunning %>deployprogress-step-active<% end_if %>">
+		<p>$NiceName</p>
+		<% if $isRunning %>
+			<% if $Up.RunningOptions %><% loop $Up.RunningOptions %>
+				<a class="btn btn-small $ButtonType btn-tooltip" data-toggle="tooltip" title="$Title" href="$Link"
+				   <% if $Confirm %>onclick="return confirm('$Confirm.JS');"<% end_if %>
+				   >$ButtonText</a>
+			<% end_loop %><% else %>
+				<div class="progress progress-striped active">
+					<div class="bar" style="width:100%"></div>
+				</div>
+			<% end_if %>
+		<% else_if $isFinished %>
+			<% if $Responder %>
+			<p>by <em>$Responder.Name</em></p>
+			<% end_if %>
+		<% end_if %>
+	</div>
+	<% end_loop %>
+</div>
+
+<% end_uncached %>

--- a/templates/Layout/DNRoot_environment.ss
+++ b/templates/Layout/DNRoot_environment.ss
@@ -36,55 +36,9 @@
 <% if $HasPipelineSupport %>
 	<% if $CurrentPipeline %>
 		<% with $CurrentPipeline %>
-			<h3 class="pull-left">Current Deployment</h3>
-
-			<div class="btn-toolbar pull-right" id="deployprogress-actions">
-				<% if $canAbort %>
-				<div class="btn-group">
-					<a href="$Link('abort')" id="deployprogress-abort" class="btn btn-warning btn-small"
-					 onclick="return confirm('Are you sure you wish to abort this pipeline?');">
-						Abort Pipeline
-					</a>
-				</div>
-				<% end_if %>
-
-				<div class="btn-group">
-					<a class="btn" href="$Link">View Logs</a>
-					<button class="btn dropdown-toggle" data-toggle="dropdown">
-						<span class="caret"></span>
-					</button>
-					<ul class="dropdown-menu">
-						<% loop $LogOptions %>
-						<li><a href="$Link">$ButtonText</a></li>
-						<% end_loop %>
-					</ul>
-				</div>
+			<div class="Pipeline-Status">
+				<% include PipelineStatus %>
 			</div>
-
-			<%-- Deployment progress bar --%>
-			<%-- This doesn't currently allow for FrontendSteps after the NonFrontendSteps --%>
-			<% uncached %>
-			<div class="row" id="deployprogress">
-				<% loop $Steps %>
-				<div class="span3 deployprogress-step <% if $isRunning %>deployprogress-step-active<% end_if %>">
-					<p>$NiceName</p>
-					<% if $isRunning %>
-						<% if $Up.RunningOptions %><% loop $Up.RunningOptions %>
-						<a class="btn btn-small $ButtonType btn-tooltip" data-toggle="tooltip" title="$Title" href="$Link">$ButtonText</a>
-						<% end_loop %><% else %>
-						<div class="progress progress-striped active">
-							<div class="bar" style="width:100%"></div>
-						</div>
-						<% end_if %>
-					<% else_if $isFinished %>
-						<% if $Responder %>
-						<p>by <em>$Responder.Name</em></p>
-						<% end_if %>
-					<% end_if %>
-				</div>
-				<% end_loop %>
-			</div>
-			<% end_uncached %>
 		<% end_with %>
 	<% else %>
 		<h3>Initiate the release process</h3>


### PR DESCRIPTION
- Running description has been re-enabled. This was actually made a long time ago but was refactored out by accident.
- Automatically make step names human-readable if not specified with NiceName or NiceDone

Before:

![image](https://cloud.githubusercontent.com/assets/936064/4470518/3a026e08-4928-11e4-8e1b-fe50cad7c40d.png)

After:

![image](https://cloud.githubusercontent.com/assets/936064/4470514/29393746-4928-11e4-93f8-f2767397f845.png)
