### PR TITLE
Set deployment backends per environments

### DIFF
--- a/_config/dnroot.yml
+++ b/_config/dnroot.yml
@@ -2,11 +2,8 @@
 Name: deploynaut
 ---
 Injector:
-  DeploymentBackend:
-    class: CapistranoDeploymentBackend
   DNData:
     properties:
-      Backend: '%$DeploymentBackend'
       # Set EnvironmentDir and KeyDir to absolute paths in your live project
       EnvironmentDir: "../deploynaut-resources/envs"
       KeyDir: "../deploynaut-resources/gitkeys"

--- a/code/jobs/DataTransferJob.php
+++ b/code/jobs/DataTransferJob.php
@@ -59,13 +59,13 @@ class DataTransferJob {
 			// before we push data to an environment, we'll make a backup first
 			if($backupJob) {
 				$log->write('Backing up existing data');
-				$this->DNData()->Backend()->dataTransfer(
+				$environment->Backend()->dataTransfer(
 					$backupJob,
 					$log
 				);
 			}
 
-			$this->DNData()->Backend()->dataTransfer(
+			$environment->Backend()->dataTransfer(
 				$dataTransfer,
 				$log
 			);

--- a/code/jobs/DeployJob.php
+++ b/code/jobs/DeployJob.php
@@ -38,7 +38,7 @@ class DeployJob {
 		$DNEnvironment = $DNProject->Environments()->filter('Name', $this->args['environmentName'])->First();
 		// This is a bit icky, but there is no easy way of capturing a failed deploy by using the PHP Resque
 		try {
-			$this->DNData()->Backend()->deploy(
+			$DNEnvironment->Backend()->deploy(
 				$DNEnvironment,
 				$this->args['sha'],
 				$log,

--- a/code/jobs/PingJob.php
+++ b/code/jobs/PingJob.php
@@ -38,6 +38,6 @@ class PingJob {
 		$log = new DeploynautLogFile($this->args['logfile']);
 		$DNProject = $this->DNData()->DNProjectList()->filter('Name', $this->args['projectName'])->First();
 		$DNEnvironment = $DNProject->Environments()->filter('Name', $this->args['environmentName'])->First();
-		$this->DNData()->Backend()->ping($DNEnvironment, $log, $DNProject);
+		$DNEnvironment->Backend()->ping($DNEnvironment, $log, $DNProject);
 	}
 }

--- a/code/model/DNData.php
+++ b/code/model/DNData.php
@@ -48,11 +48,6 @@ class DNData extends ViewableData {
 		return Injector::inst()->get('DNData');
 	}
 
-	/**
-	 * @var DeploymentBackend
-	 */
-	protected $backend;
-
 	public function __construct($environmentDir = null, $keyDir = null, $dataTransferDir = null, $gitUser = null) {
 		parent::__construct();
 
@@ -158,23 +153,6 @@ class DNData extends ViewableData {
 	 */
 	public function DNProjectList() {
 		return DNProject::get();
-	}
-
-	/**
-	 *
-	 * @return DeploymentBackend
-	 */
-	public function Backend() {
-		return $this->backend;
-	}
-
-	/**
-	 * Sets the backend
-	 *
-	 * @param DeploymentBackend $backend
-	 */
-	public function setBackend(DeploymentBackend $backend) {
-		$this->backend = $backend;
 	}
 
 	/**

--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -141,6 +141,13 @@ class DNEnvironment extends DataObject {
 	private static $default_sort = 'Name';
 
 	/**
+	 * Which deployment backend does this environment use.
+	 *
+	 * @var string
+	 */
+	protected $deploymentBackend = "CapistranoDeploymentBackend";
+
+	/**
 	 *
 	 * @todo this should probably be refactored so it don't interfere with the default
 	 * DataObject::get() behaviour.
@@ -173,6 +180,15 @@ class DNEnvironment extends DataObject {
 		$adminGroup = Group::get()->filter('Code', 'administrators')->first();
 		$e->DeployerGroups()->add($adminGroup);
 		return $e;
+	}
+
+	/**
+	 * Get the deployment backend used for this environment
+	 *
+	 * @return DeploymentBackend
+	 */
+	public function Backend() {
+		return Object::create_from_string($this->deploymentBackend);
 	}
 
 	/**
@@ -1144,9 +1160,7 @@ PHP
 	 * @param DeploynautLogFile $log
 	 */
 	public function enableMaintenace($log) {
-		$this
-			->DNData()
-			->Backend()
+		$this->Backend()
 			->enableMaintenance($this, $log, $this->Project());
 	}
 
@@ -1156,9 +1170,7 @@ PHP
 	 * @param DeploynautLogFile $log
 	 */
 	public function disableMaintenance($log) {
-		$this
-			->DNData()
-			->Backend()
+		$this->Backend()
 			->disableMaintenance($this, $log, $this->Project());
 	}
 

--- a/code/model/DNProject.php
+++ b/code/model/DNProject.php
@@ -507,11 +507,15 @@ class DNProject extends DataObject {
 	 * Setup a gridfield for the environment configs
 	 *
 	 * @param FieldList $fields
+	 * @param $environments
+	 * @return void
 	 */
 	protected function setEnvironmentFields(&$fields, $environments) {
 		if(!$environments) {
-			return false;
+			return;
 		}
+
+		$environments->getConfig()->addComponent(new GridFieldAddNewMultiClass());
 		$environments->getConfig()->removeComponentsByType('GridFieldAddNewButton');
 		$environments->getConfig()->removeComponentsByType('GridFieldAddExistingAutocompleter');
 		$environments->getConfig()->removeComponentsByType('GridFieldDeleteAction');

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 		"stojg/silverstripe-resque": "1.1.*",
 		"gitonomy/gitlib": "dev-master",
 		"undefinedoffset/sortablegridfield": "*",
-		"silverstripe/secureassets": "dev-master"
+		"silverstripe/secureassets": "dev-master",
+		"ajshort/silverstripe-gridfieldextensions": "dev-master"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~3.7@stable"

--- a/tests/DeploynautTest.php
+++ b/tests/DeploynautTest.php
@@ -20,7 +20,6 @@ abstract class DeploynautTest extends SapphireTest {
 		Injector::inst()->load(array(
 			'DNData' => array(
 				'properties' => array(
-					'Backend' => '%$DeploymentBackend',
 					'EnvironmentDir' => $this->envPath,
 					'KeyDir' => TEMP_FOLDER .'/deploynaut_test/gitkeys',
 					'DataTransferDir' => Director::baseFolder() . '/assets/transfers',
@@ -36,7 +35,6 @@ abstract class DeploynautTest extends SapphireTest {
 		Injector::nest();
 		Injector::inst()->load(array(
 			'DNProject' => 'DeploynautTest_Project',
-			'DeploymentBackend' => 'DemoDeploymentBackend'
 		));
 
 		// Set temp location

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -213,3 +213,14 @@ class PipelineTest_DNDataTransfer extends DNDataTransfer implements TestOnly {
 		return $this->Status === 'Finished' ? 'Complete' : $this->Status;
 	}
 }
+
+class PipelineTest_Environment extends DNEnvironment implements TestOnly {
+
+	/**
+	 * Use the demo backend
+	 *
+	 * @var string
+	 */
+	protected $deploymentBackend = "DemoDeploymentBackend";
+
+}

--- a/tests/PipelineTest.yml
+++ b/tests/PipelineTest.yml
@@ -14,7 +14,7 @@ Member:
 DNProject:
   testproject:
     Name: 'testproject'
-DNEnvironment:
+PipelineTest_Environment:
   uat:
     Name: uat
     Project: =>DNProject.testproject
@@ -22,11 +22,11 @@ DNEnvironment:
 Pipeline:
   testpipesmoketest:
     Author: =>Member.author
-    Environment: =>DNEnvironment.uat
+    Environment: =>PipelineTest_Environment.uat
     SHA: '9ae502821345ab39b04d46ce6bb822ccdd7f7414'
   testpipe:
     Author: =>Member.author
-    Environment: =>DNEnvironment.uat
+    Environment: =>PipelineTest_Environment.uat
     SHA: '9ae502821345ab39b04d46ce6bb822ccdd7f7414'
     RollbackStep1ID: 1
 UserConfirmationStep:


### PR DESCRIPTION
This removes the "global" setting of deployment backend and relies that the different sub-types of DNEnvironment will set this in the $deploymentBackend variable.
