### PR TITLE
API Enable dry-run of pipelines

### DIFF
--- a/code/control/ConfirmationMessagingService.php
+++ b/code/control/ConfirmationMessagingService.php
@@ -9,7 +9,7 @@ interface ConfirmationMessagingService {
 	/**
 	 * Sends a message to the specified user
 	 * 
-	 * @param PipelineStep $source Source client step
+	 * @param PipelineData $source Source client step
 	 * @param string $message Plain text message
 	 * @param mixed $recipients Either a Member object, string, or array of strings or Member objects
 	 * @param array $arguments Additional arguments that may be configured

--- a/code/control/DeployForm.php
+++ b/code/control/DeployForm.php
@@ -104,6 +104,7 @@ class DeployForm extends Form {
 		if($environment->HasPipelineSupport()) {
 			// Determine if commits are filtered
 			$canBypass = Permission::check(DNRoot::DEPLOYNAUT_BYPASS_PIPELINE);
+			$canDryrun = $environment->DryRunEnabled && Permission::check(DNRoot::DEPLOYNAUT_DRYRUN_PIPELINE);
 			$commits = $environment->getDependentFilteredCommits();
 			if(empty($commits)) {
 				// There are no filtered commits, so show all commits
@@ -125,6 +126,18 @@ class DeployForm extends Form {
 					->addExtraClass('btn btn-primary')
 					->setAttribute('onclick', "return confirm('This will begin a release pipeline. Continue?');")
 			);
+			if($canDryrun) {
+				$actions->push(
+					FormAction::create('doDryRun', "Dry-run release process")
+						->addExtraClass('btn btn-info')
+						->setAttribute('onclick',
+							"return confirm('This will begin a release pipeline, but with the following exclusions:\\n" .
+							" - No messages will be sent\\n" .
+							" - No capistrano actions will be invoked\\n".
+							" - No deployments or snapshots will be created.');"
+						)
+				);
+			}
 			if($canBypass) {
 				$actions->push(
 					FormAction::create('doDeploy', "Direct deployment (bypass pipeline)")

--- a/code/control/EmailMessagingService.php
+++ b/code/control/EmailMessagingService.php
@@ -16,7 +16,7 @@ class EmailMessagingService implements ConfirmationMessagingService {
 	 * @config
 	 * @var string
 	 */
-	private static $default_subject = 'Confirmation required for deployment';
+	private static $default_subject = 'Deploynaut notification';
 
 	public function sendMessage($source, $message, $recipients, $arguments = array()) {
 		$from = empty($arguments['from'])
@@ -90,8 +90,12 @@ class EmailMessagingService implements ConfirmationMessagingService {
 	 */
 	protected function sendViaEmail($source, $from, $to, $subject, $body) {
 		$email = new Email($from, $to, $subject, $body);
-		$email->sendPlain();
-		$source->log("Sent message to $to (subject: $subject)");
+		if($source->getDryRun()) {
+			$source->log("[Skipped] Sent message to $to (subject: $subject)");
+		} else {
+			$email->sendPlain();
+			$source->log("Sent message to $to (subject: $subject)");
+		}
 	}
 
 }

--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -9,6 +9,7 @@
  * @property string $URL URL Of this environment
  * @property string $Name
  * @property string $GraphiteServers
+ * @property bool $DryRunEnabled
  * @method DNProject Project()
  * @method DataList Deployments()
  *
@@ -63,6 +64,7 @@ class DNEnvironment extends DataObject {
 		"Filename" => "Varchar(255)",
 		"Name" => "Varchar",
 		"URL" => "Varchar",
+		"DryRunEnabled" => "Boolean" // True if the dry run button should be enabled on the frontend
 	);
 
 	/**
@@ -914,7 +916,16 @@ PHP
 				"No pipeline is configured for this environment. Saving content here will generate a new template."
 			);
 		}
-		$fields->addFieldToTab('Root.PipelineTemplate', $deployConfig);
+		$fields->addFieldsToTab('Root.PipelineSettings', array(
+			FieldGroup::create(
+				CheckboxField::create('DryRunEnabled', 'Enable dry-run?')
+			)
+				->setTitle('Pipeline Options')
+				->setDescription(
+					"Allows admins to run simulated pipelines without triggering deployments or notifications."
+				),
+			$deployConfig
+		));
 	}
 
 	/**

--- a/code/model/PipelineData.php
+++ b/code/model/PipelineData.php
@@ -1,0 +1,19 @@
+<?php
+
+interface PipelineData {
+
+	/**
+	 * Is this a dry run?
+	 *
+	 * @return bool
+	 */
+	public function getDryRun();
+
+	/**
+	 * Log message
+	 * 
+	 * @param string $message The message to log
+	 * @return void
+	 */
+	public function log($message);
+}

--- a/code/model/steps/PipelineStep.php
+++ b/code/model/steps/PipelineStep.php
@@ -17,7 +17,7 @@
  * @package deploynaut
  * @subpackage pipeline
  */
-class PipelineStep extends DataObject {
+class PipelineStep extends DataObject implements PipelineData {
 
 	/**
 	 * @var array
@@ -277,5 +277,9 @@ class PipelineStep extends DataObject {
 	public function allowedActions() {
 		return array();
 	}
-}
 
+	public function getDryRun() {
+		return $this->Pipeline()->DryRun;
+	}
+
+}

--- a/code/model/steps/SmokeTestPipelineStep.php
+++ b/code/model/steps/SmokeTestPipelineStep.php
@@ -170,9 +170,13 @@ class SmokeTestPipelineStep extends PipelineStep {
 	}
 
 	public function markFailed($notify = true) {
-		// Put up maintenance page after this fails
-		$this->log("Smoke testing failed: Putting up emergency maintenance page");
-		$this->Pipeline()->Environment()->enableMaintenace($this->Pipeline()->getLogger());
+		if($this->getDryRun()) {
+			$this->log("[Skipped] Smoke testing failed: Putting up emergency maintenance page");
+		} else {
+			// Put up maintenance page after this fails
+			$this->log("Smoke testing failed: Putting up emergency maintenance page");
+			$this->Pipeline()->Environment()->enableMaintenace($this->Pipeline()->getLogger());
+		}
 
 		// Mark pipeline and step failed
 		parent::markFailed($notify);

--- a/docs/en/pipelines.md
+++ b/docs/en/pipelines.md
@@ -89,3 +89,25 @@ their checks on.
 
 Note: All config files inherit from https://github.com/silverstripe/deploynaut/blob/master/_config/pipeline.yml
 
+## Testing
+
+When setup on a server, a dry-run of a complete pipeline can be initiated by a user with the appropriate permission,
+(or logged in as admin). To enable dry-running of pipelines for any environment, edit the environment in the CMS,
+and check the "Enable dry run?" option under the "Pipeline Settings" tab.
+
+This will enable a new deployment option on the front end, with the label "Dry-run release process".
+
+This process differs from the normal pipeline execution in the following ways:
+
+* Messages are not sent to users
+* Capistrano commands will not execute
+* Deployments or snapshots will not be initiated
+
+Whenever an action would normally be taken, the subsequent log message will be prefixed with "[Skipped]" to denote
+an action skipped by the dry-run.
+
+These actions are taken as per normal:
+
+* Smoke tests
+* User front-end actions
+* Logging

--- a/tests/DeploymentPipelineStepTest.php
+++ b/tests/DeploymentPipelineStepTest.php
@@ -5,7 +5,7 @@ class DeploymentPipelineStepTest extends PipelineTest {
 	protected static $fixture_file = 'PipelineTest.yml';
 
 	/**
-	 * Makse the dummy deployment step
+	 * Makes the dummy deployment step
 	 *
 	 * @return DeploymentPipelineStep
 	 */

--- a/tests/DryRunPipelineTest.php
+++ b/tests/DryRunPipelineTest.php
@@ -1,0 +1,155 @@
+<?php
+
+class DryRunPipelineTest extends PipelineTest {
+
+	protected static $fixture_file = 'PipelineTest.yml';
+
+	/**
+	 * Makes the dummy pipeline
+	 *
+	 * @return Pipeline
+	 */
+	public function getDummyPipeline() {
+		// Load data into step and pipeline
+		$data = $this->getPipelineConfig();
+		$pipeline = $this->objFromFixture('Pipeline', 'testpipe');
+		$pipeline->Config = serialize($data);
+		$pipeline->DryRun = true;
+		$pipeline->write();
+
+		return $pipeline;
+	}
+
+	/**
+	 * Makes the dummy deployment step
+	 *
+	 * @return DeploymentPipelineStep
+	 */
+	public function getDummyDeployment() {
+		$deployStep = $this->objFromFixture('DeploymentPipelineStep', 'testdeploy');
+		$deployStep->Config = serialize(array('MaxDuration' => '3600'));
+		$deployStep->write();
+		$pipeline = $deployStep->Pipeline();
+		$pipeline->Config = serialize(array());
+		$pipeline->DryRun = true;
+		$pipeline->write();
+		return $deployStep;
+	}
+
+	/**
+	 * @return RollbackStep
+	 */
+	public function getDummyRollback() {
+		$rollbackStep = RollbackStep::create();
+		$rollbackStep->Status = 'Queued';
+		$rollbackStep->Doing = 'Queued';
+		$rollbackStep->Config = serialize(array(
+			'Class' => 'RollbackStep',
+			'MaxDuration' => '3600',
+			'RestoreDB' => true
+		));
+		$rollbackStep->write();
+		$pipeline = $this->getDummyPipeline();
+		$pipeline->RollbackStep1 = $rollbackStep->ID;
+		$rollbackStep->PipelineID = $pipeline->ID;
+		$rollbackStep->write();
+		$pipeline->write();
+		return $rollbackStep;
+
+	}
+
+	/**
+	 * Test messages aren't sent
+	 */
+	public function testMessages() {
+		$pipeline = $this->getDummyPipeline();
+		$sender = new EmailMessagingService();
+		$sender->sendMessage($pipeline, 'Test message', 'noreply@example.com');
+		$this->assertHasLog('[Skipped] Sent message to noreply@example.com (subject: Deploynaut notification)');
+	}
+
+	/**
+	 * Test deployments dont do anything
+	 */
+	public function testDeployment() {
+		$step = $this->getDummyDeployment();
+
+		// First run; creates snapshot
+		$step->start();
+		$this->assertHasLog('TestDeployStep:Snapshot creating snapshot of database');
+		$this->assertHasLog('[Skipped] Create DNDataTransfer backup');
+
+
+		// Second run, finalises snapshot and creates deployment
+		PipelineTest_MockLog::clear();
+		$step->start();
+		$this->assertHasLog('Checking status of TestDeployStep:Snapshot...');
+		$this->assertHasLog('[Skipped] Checking progress of snapshot backup');
+		$this->assertHasLog('TestDeployStep:Deployment starting deployment');
+		$this->assertHasLog('[Skipped] Create DNDeployment for SHA 9ae502821345ab39b04d46ce6bb822ccdd7f7414');
+
+		// Third run, complete deployment
+		PipelineTest_MockLog::clear();
+		$step->start();
+		$this->assertHasLog('Checking status of TestDeployStep:Deployment...');
+		$this->assertHasLog('[Skipped] Checking progress of deployment');
+	}
+
+	/**
+	 * Test the rollback step
+	 */
+	public function testRollback() {
+		$step = $this->getDummyRollback();
+
+		// First run, start revert code
+		$step->start();
+		$this->assertHasLog('RollbackStep:Deployment starting revert deployment');
+		$this->assertHasLog('[Skipped] Create DNDeployment');
+
+		// Second run, finish deployment and start database restoration
+		PipelineTest_MockLog::clear();
+		$step->start();
+		$this->assertHasLog('Checking status of RollbackStep:Deployment...');
+		$this->assertHasLog('[Skipped] Checking progress of deployment');
+		$this->assertHasLog('RollbackStep:Snapshot reverting database from snapshot');
+		$this->assertHasLog('[Skipped] Create DNDataTransfer restore');
+
+		// Third run, complete snapshot restore
+		PipelineTest_MockLog::clear();
+		$step->start();
+		$this->assertHasLog('Checking status of RollbackStep:Snapshot...');
+		$this->assertHasLog('[Skipped] Checking progress of snapshot restore');
+		$this->assertHasLog('Step finished successfully!');
+	}
+
+	/**
+	 * Make the dummy deployment step
+	 *
+	 * @return SmokeTestPipelineStep
+	 */
+	public function getDummySmokeTestStep($name) {
+		// Load data inte step and pipeline
+		$data = $this->getPipelineConfig();
+		$smokeStep = $this->objFromFixture('SmokeTestPipelineStep', 'testsmoketest');
+		$pipeline = $smokeStep->Pipeline();
+		$pipeline->Config = serialize($data);
+		$pipeline->DryRun = true;
+		$pipeline->write();
+		$smokeStep->Config = serialize($pipeline->getConfigSetting('Steps', $name));
+		$smokeStep->write();
+		return $smokeStep;
+	}
+
+	/**
+	 * Test failed smoke test
+	 */
+	public function testSmokeTestFail() {
+		// the testsmokefaile yml config contains a invalid smoketest url
+		// which is how it fails
+		$step = $this->getDummySmokeTestStep('FailTest');
+		$step->start();
+		$this->assertHasLog('Starting smoke test "BrokenPage" to URL http://bob.bob.bob.bob/');
+		$this->assertHasLog('Curl error: ');
+		$this->assertHasLog('[Skipped] Smoke testing failed: Putting up emergency maintenance page');
+	}
+}


### PR DESCRIPTION
This means that if we deploy deploynaut to a server, we can do a dry-run of all tests to make sure that the system is working correctly, BEFORE the client actually tries to do a live deployment of their own.
