### PR TITLE
Fix strict error about references

### DIFF
--- a/code/control/DeployForm.php
+++ b/code/control/DeployForm.php
@@ -282,7 +282,8 @@ class DeployForm extends Form {
 	public function getSelectedBuild($data) {
 		if(isset($data['SelectRelease']) && !empty($data[$data['SelectRelease']])) {
 			// Filter out the tag/branch name if required
-			return reset(explode('-', $data[$data['SelectRelease']]));
+			$array = explode('-', $data[$data['SelectRelease']]);
+			return reset($array);
 		}
 		if(isset($data['FilteredCommits']) && !empty($data['FilteredCommits'])) {
 			return $data['FilteredCommits'];


### PR DESCRIPTION
reset() takes a variable by reference, so previously this was an error.
