### PR TITLE
Refactor capistrano roles to be requested from cap commands everywhere.

### DIFF
--- a/code/backends/CapistranoDeploymentBackend.php
+++ b/code/backends/CapistranoDeploymentBackend.php
@@ -40,7 +40,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			'branch' => $sha,
 			'repository' => $repository
 		);
-		$command = $this->getCommand('deploy', $projectName.':'.$environmentName, $args, $env, $log);
+		$command = $this->getCommand('deploy', 'web', $projectName.':'.$environmentName, $args, $env, $log);
 		$command->run(function ($type, $buffer) use($log) {
 			$log->write($buffer);
 		});
@@ -70,7 +70,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 	public function enableMaintenance(DNEnvironment $environment, DeploynautLogFile $log, DNProject $project) {
 		// Perform the enabling
 		$env = $project->getProcessEnv();
-		$command = $this->getCommand('maintenance:enable', $project->Name.':'.$environment->Name, null, $env, $log);
+		$command = $this->getCommand('maintenance:enable', 'web', $project->Name.':'.$environment->Name, null, $env, $log);
 		$command->run(function ($type, $buffer) use($log) {
 			$log->write($buffer);
 		});
@@ -86,7 +86,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 	public function disableMaintenance(DNEnvironment $environment, DeploynautLogFile $log, DNProject $project) {
 		// Perform the disabling
 		$env = $project->getProcessEnv();
-		$command = $this->getCommand('maintenance:disable', $project->Name.':'.$environment->Name, null, $env, $log);
+		$command = $this->getCommand('maintenance:disable', 'web', $project->Name.':'.$environment->Name, null, $env, $log);
 		$command->run(function ($type, $buffer) use($log) {
 			$log->write($buffer);
 		});
@@ -101,7 +101,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 	 */
 	public function ping(DNEnvironment $environment, DeploynautLogFile $log, DNProject $project) {
 		$env = $project->getProcessEnv();
-		$command = $this->getCommand('deploy:check', $project->Name.':'.$environment->Name, null, $env, $log);
+		$command = $this->getCommand('deploy:check', 'web', $project->Name.':'.$environment->Name, null, $env, $log);
 		$command->run(function ($type, $buffer) use($log) {
 			$log->write($buffer);
 			echo $buffer;
@@ -127,13 +127,14 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 
 	/**
 	 * @param string $action Capistrano action to be executed
+	 * @param string $roles Defining a server role is required to target only the required servers.
 	 * @param string $environment Capistrano identifier for the environment (see capistrano-multiconfig)
 	 * @param array $args Additional arguments for process
 	 * @param string $env Additional environment variables
 	 * @param DeploynautLogFile $log
 	 * @return \Symfony\Component\Process\Process
 	 */
-	protected function getCommand($action, $environment, $args = null, $env = null, DeploynautLogFile $log) {
+	protected function getCommand($action, $roles, $environment, $args = null, $env = null, DeploynautLogFile $log) {
 		if(!$args) $args = array();
 		$args['history_path'] = realpath(DEPLOYNAUT_LOG_PATH.'/');
 
@@ -163,7 +164,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 		}
 		file_put_contents($capFile, $cap);
 
-		$command = "{$envString}cap -f " . escapeshellarg($capFile) . " -vv $environment $action";
+		$command = "{$envString}cap -f " . escapeshellarg($capFile) . " -vv $environment $action ROLES=$roles";
 		foreach($args as $argName => $argVal) {
 			$command .= ' -s ' . escapeshellarg($argName) . '=' . escapeshellarg($argVal);
 		}
@@ -214,7 +215,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			$args = array(
 				'data_path' => $databasePath
 			);
-			$command = $this->getCommand("data:getdb", $name, $args, $env, $log);
+			$command = $this->getCommand("data:getdb", 'db', $name, $args, $env, $log);
 			$command->run(function ($type, $buffer) use($log) {
 				$log->write($buffer);
 			});
@@ -230,7 +231,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			$args = array(
 				'data_path' => $filepathBase
 			);
-			$command = $this->getCommand("data:getassets", $name, $args, $env, $log);
+			$command = $this->getCommand("data:getassets", 'web', $name, $args, $env, $log);
 			$command->run(function ($type, $buffer) use($log) {
 				$log->write($buffer);
 			});
@@ -313,7 +314,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 	 */
 	public function rebuild($name, $env, $log) {
 		// Rebuild db and flush.
-		$command = $this->getCommand('deploy:migrate', $name, null, $env, $log);
+		$command = $this->getCommand('deploy:migrate', 'web', $name, null, $env, $log);
 		$command->run(function ($type, $buffer) use($log) {
 			$log->write($buffer);
 		});
@@ -375,8 +376,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			$args = array(
 				'data_path' => $tempPath . DIRECTORY_SEPARATOR . 'database.sql.gz'
 			);
-			$command = "data:pushdb";
-			$command = $this->getCommand($command, $name, $args, $env, $log);
+			$command = $this->getCommand('data:pushdb', 'db', $name, $args, $env, $log);
 			$command->run(function ($type, $buffer) use($log) {
 				$log->write($buffer);
 			});
@@ -414,8 +414,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			$args = array(
 				'data_path' => $tempPath . DIRECTORY_SEPARATOR . 'assets'
 			);
-			$command = "data:pushassets";
-			$command = $this->getCommand($command, $name, $args, $env, $log);
+			$command = $this->getCommand('data:pushassets', 'web', $name, $args, $env, $log);
 			$command->run(function ($type, $buffer) use($log) {
 				$log->write($buffer);
 			});

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -167,6 +167,21 @@ To fix this, change to the deploy user and connect to the machine and answer yes
 	sudo su - www-data
 	ssh -p 2222 sites@192.168.0.1
 
+## Capistrano roles
+
+The following deploy targets are used:
+
+ * :web - target for deploy, asset transfer and maintenance tasks. 
+ * :db - target for db transfers.
+
+Servers with other roles will not be operated on.
+
+Please note that original capistrano tasks only rely on a `no_release` flag, and roles are not respected for tasks such
+as [`deploy:update_code`](https://github.com/capistrano/capistrano/blob/v2.14.2/lib/capistrano/recipes/deploy.rb#L246).
+To make capistrano respect the roles we have added the `ROLES` variable to cap command line invocations in the
+`CapistranoDeploymentBackend` (the targets might still be further limited in the specific tasks using `:once` or
+`:except` within the tasks).
+
 ## Configuring snapshots
 
 Create `assets/transfers` server-writable directory:

--- a/ruby/deploy.rb
+++ b/ruby/deploy.rb
@@ -34,17 +34,17 @@ namespace :deploy do
 			sake = "#{bash} #{latest_release}/#{sake_path}";
 			
 			# Prepare temporary cache
-			unless exists?(:webserver_user) then run "mkdir -p #{latest_release}/silverstripe-cache", :roles => :web end
+			unless exists?(:webserver_user) then run "mkdir -p #{latest_release}/silverstripe-cache" end
 			
 			# Flush and build database
-			run "#{sake} dev flush=1", :roles => :web # Flush all servers
-			run "#{sake} dev/build", :roles => :web, :once => true # Limit DB operations to a single node
+			run "#{sake} dev flush=1" # Flush all servers
+			run "#{sake} dev/build", :once => true # Limit DB operations to a single node
 			
 			# Cleanup temporary cache
-			unless exists?(:webserver_user) then run "rm -rf #{latest_release}/silverstripe-cache", :roles => :web end
+			unless exists?(:webserver_user) then run "rm -rf #{latest_release}/silverstripe-cache" end
 			
 			# Initialise the cache, in case dev/build wasn't executed on all hosts
-			run "#{sake} dev", :roles => :web
+			run "#{sake} dev"
 		end
 
 		# Run custom post-migration script.
@@ -54,7 +54,7 @@ namespace :deploy do
 	end
 
 	task :restart do
-		system "echo \""+Time.now.strftime("%Y-%m-%d %H:%M:%S")+" => #{branch} \" >> #{history_path}/#{config_name}.deploy-history.txt";
+		system "echo \""+Time.now.strftime("%Y-%m-%d %H:%M:%S")+" => #{branch} \" >> #{history_path}/#{config_name}.deploy-history.txt"
 		logger.debug "Deploy finished."
 	end
 

--- a/ruby/maintenance.rb
+++ b/ruby/maintenance.rb
@@ -41,10 +41,10 @@ namespace :maintenance do
 
 			# if there's no custom maintenance page found above, use a default one supplied with deploynaut
 			if custom_maintenance == nil
-				upload(File.expand_path("../maintenance.html.template", File.dirname(__FILE__)), current_path + "/maintenance.html")
+				upload File.expand_path("../maintenance.html.template", File.dirname(__FILE__)), current_path + "/maintenance.html"
 			end
 
-			upload(File.expand_path("../maintenance.htaccess.template", File.dirname(__FILE__)), current_path + "/.htaccess")
+			upload File.expand_path("../maintenance.htaccess.template", File.dirname(__FILE__)), current_path + "/.htaccess"
 		end
 	end
 


### PR DESCRIPTION
The CapistranoDeploymentBackend will now reinforce the use of roles, and
scripts have been refactored to work in tandem, only relying on :once
and :except where needed.
