### PR TITLE
BUG Fix logic in deployer detection

### DIFF
--- a/code/model/steps/DeploymentPipelineStep.php
+++ b/code/model/steps/DeploymentPipelineStep.php
@@ -89,9 +89,10 @@ class DeploymentPipelineStep extends LongRunningPipelineStep {
 		$deployment = DNDeployment::create();
 		$deployment->EnvironmentID = $environment->ID;
 		$deployment->SHA = $pipeline->SHA;
-		if($previous = $pipeline->findPreviousStep()) {
-			$deployment->DeployerID = $previous->ResponderID ?: $pipeline->AuthorID;
-		}
+		$previousStep = $pipeline->findPreviousStep();
+		$deployment->DeployerID = ($previousStep && $previousStep->ResponderID)
+			? $previousStep->ResponderID
+			: $pipeline->AuthorID;
 		$deployment->write();
 		$deployment->start();
 		$pipeline->CurrentDeploymentID = $deployment->ID;

--- a/tests/DeploymentPipelineStepTest.php
+++ b/tests/DeploymentPipelineStepTest.php
@@ -41,7 +41,9 @@ class DeploymentPipelineStepTest extends PipelineTest {
 		$this->assertTrue(PipelineTest_MockLog::has_message('TestDeployStep:Deployment starting deployment'));
 
 		// Mark the service as completed and check result
+		$author = $this->objFromFixture('Member', 'author');
 		$deployment = $step->Pipeline()->CurrentDeployment();
+		$this->assertEquals($deployment->DeployerID, $author->ID);
 		$deployment->markFinished();
 
 		// Retry step

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -142,6 +142,21 @@ class PipelineTest_RecordingMessageSender extends EmailMessagingService implemen
  */
 class PipelineTest_DNDeployment extends DNDeployment implements TestOnly {
 
+	public function __construct($record = null, $isSingleton = false, $model = null) {
+		// Set the fields data.
+		if(!$record) {
+			$record = array(
+				'ID' => 0,
+				'ClassName' => 'DNDeployment',
+				'RecordClassName' => 'DNDeployment'
+			);
+		}
+
+		parent::__construct($record, $isSingleton, $model);
+
+		$this->class = 'DNDeployment';
+	}
+
 	protected function enqueueDeployment() {
 		// Mock behaviour of enqueue without actually enqueuing anything
 		$environment = $this->Environment();
@@ -193,6 +208,21 @@ class PipelineTest_DNDeployment extends DNDeployment implements TestOnly {
 }
 
 class PipelineTest_DNDataTransfer extends DNDataTransfer implements TestOnly {
+
+	public function __construct($record = null, $isSingleton = false, $model = null) {
+		// Set the fields data.
+		if(!$record) {
+			$record = array(
+				'ID' => 0,
+				'ClassName' => 'DNDataTransfer',
+				'RecordClassName' => 'DNDataTransfer'
+			);
+		}
+
+		parent::__construct($record, $isSingleton, $model);
+
+		$this->class = 'DNDataTransfer';
+	}
 
 	public function start() {
 		$this->Status = 'Queued';


### PR DESCRIPTION
In some cases the DeployerID isn't set properly on the DNDeployment.

Also fixes a minor issue in the unit tests where substituted classes aren't saved properly to the DB.
