### PR TITLE
Re-order the different ways to deploy a commit

### DIFF
--- a/code/control/DeployForm.php
+++ b/code/control/DeployForm.php
@@ -212,18 +212,18 @@ class DeployForm extends Form {
 				'Deploy a commit prepared for this pipeline'
 			);
 		}
-		if($tags) {
-			$releaseMethods[] = new SelectionGroup_Item(
-				'Tag',
-				new DropdownField('Tag', '', $tags),
-				'Deploy a tagged release'
-			);
-		}
 		if($branches) {
 			$releaseMethods[] = new SelectionGroup_Item(
 				'Branch',
 				new DropdownField('Branch', '', $branches),
 				'Deploy the latest version of a branch'
+			);
+		}
+		if($tags) {
+			$releaseMethods[] = new SelectionGroup_Item(
+				'Tag',
+				new DropdownField('Tag', '', $tags),
+				'Deploy a tagged release'
 			);
 		}
 		if($redeploy) {


### PR DESCRIPTION
This change is based off empirical data gathered through a live and well-used Deploynaut instance.

Statistics:
- Branch 85.2%
- Redeploy 0.0%
- SHA 9.2%
- Tag 3.4%

With SHA and Branch being the two most used options, Branch is selected by default, with SHA being at the bottom of the list (thus easy to see and click, also that's where it currently is).
