### PR TITLE
Add a flush parameter for snapshot sniffer script

### DIFF
--- a/ruby/data.rb
+++ b/ruby/data.rb
@@ -165,6 +165,7 @@ namespace :data do
 		define('BASE_URL', '/');
 		$_SERVER['HTTP_HOST'] = 'localhost';
 		chdir(BASE_PATH);
+		$_GET['flush'] = 1;
 		require_once '#{core_file}';
 		#{phpcode} ; "
 


### PR DESCRIPTION
Attempted fix for #65 

I believe it will always let you flush from the CLI, but some confirmation would be great (seemed to work in all my testing).
