### PR TITLE
API Enable reattempts for smoketesting

### DIFF
--- a/tests/PipelineTest_Config.yml
+++ b/tests/PipelineTest_Config.yml
@@ -76,6 +76,15 @@ Steps:
       BrokenPage:
         URL: http://bob.bob.bob.bob/
         ExpectStatus: 200
+  RepeatTest:
+    Class: SmokeTestPipelineStep
+    MaxDuration: 3600
+    Attempts: 3
+    AttemptDelay: 1
+    Tests:
+      BrokenPage:
+        URL: http://bob.bob.bob.bob/
+        ExpectStatus: 200
   RequestDeploymentStep:
     Class: TriggerDeployStep
     MaxDuration: 86400 # Auto time out after a day

--- a/tests/SmokeTestPipelineStepTest.php
+++ b/tests/SmokeTestPipelineStepTest.php
@@ -48,4 +48,18 @@ class SmokeTestPipelineStepTest extends PipelineTest {
 		$this->assertHasLog('Smoke test "Home" to URL https://github.com/ successful');
 		$this->assertEquals('Failed', $step->Status);
 	}
+
+	public function testReattempts() {
+		// the testsmokefaile yml config contains a invalid smoketest url which is how it fails
+		$step = $this->getDummySmokeTestStep('RepeatTest');
+		$this->assertFalse($step->start());
+		$this->assertHasLog('Starting smoke test "BrokenPage" to URL http://bob.bob.bob.bob/');
+		$this->assertHasLog('Curl error: ');
+		$this->assertHasLog('Starting smoke test "Home" to URL https://github.com/');
+		$this->assertHasLog('Smoke test "Home" to URL https://github.com/ successful');
+		$this->assertHasLog('Request failed, performing reattempt (#1)');
+		$this->assertHasLog('Request failed, performing reattempt (#2)');
+		$this->assertHasLog('Failed after 3 attempts');
+		$this->assertEquals('Failed', $step->Status);
+	}
 }


### PR DESCRIPTION
Useful if smoketesting should be forgiving of first-request timeouts, etc.
Set default to 1 to not allow reattempts.
Also now allow timeout to be configurable

Fixes #73 
