### PR TITLE
BUG Disallow simultaneous deployments (#92)

### DIFF
--- a/code/jobs/DataTransferJob.php
+++ b/code/jobs/DataTransferJob.php
@@ -43,14 +43,19 @@ class DataTransferJob {
 		// This is a bit icky, but there is no easy way of capturing a failed run by using the PHP Resque
 		try {
 			// Disallow concurrent jobs (don't rely on queuing implementation to restrict this)
+			// Only consider data transfers started in the last 30 minutes (older jobs probably got stuck)
 			$runningTransfers = DNDataTransfer::get()
-				->filter(array('EnvironmentID' => $environment->ID, 'Status' => array('Queued', 'Started')))
+				->filter(array(
+					'EnvironmentID' => $environment->ID,
+					'Status' => array('Queued', 'Started'),
+					'Created:GreaterThan' => strtotime('-30 minutes')
+				))
 				->exclude('ID', $dataTransfer->ID);
 
 			if($runningTransfers->count()) {
-				$runningTransfer = $runningTransfers->First();
+				$runningTransfer = $runningTransfers->first();
 				throw new RuntimeException(sprintf(
-					'[-] Error: another transfer seems to be already in progress (started at %s by %s)',
+					'[-] Error: another transfer is in progress (started at %s by %s)',
 					$runningTransfer->dbObject('Created')->Nice(),
 					$runningTransfer->Author()->Title
 				));

--- a/code/jobs/DeployJob.php
+++ b/code/jobs/DeployJob.php
@@ -38,6 +38,25 @@ class DeployJob {
 		$DNEnvironment = $DNProject->Environments()->filter('Name', $this->args['environmentName'])->First();
 		// This is a bit icky, but there is no easy way of capturing a failed deploy by using the PHP Resque
 		try {
+			// Disallow concurrent deployments (don't rely on queuing implementation to restrict this)
+			// Only consider deployments started in the last 30 minutes (older jobs probably got stuck)
+			$runningDeployments = DNDeployment::get()
+				->filter(array(
+					'EnvironmentID' => $environment->ID,
+					'Status' => array('Queued', 'Started'),
+					'Created:GreaterThan' => strtotime('-30 minutes')
+				))
+				->exclude('ID', $this->args['deploymentID']);
+
+			if($runningDeployments->count()) {
+				$runningDeployment = $runningDeployments->first();
+				throw new RuntimeException(sprintf(
+					'[-] Error: another deployment is in progress (started at %s by %s)',
+					$runningDeployment->dbObject('Created')->Nice(),
+					$runningDeployment->Deployer()->Title
+				));
+			}
+
 			$DNEnvironment->Backend()->deploy(
 				$DNEnvironment,
 				$this->args['sha'],


### PR DESCRIPTION
Works the same way as `DataTransferJob`, which currently stops anyone from
being able to perform transfers at once.