### PR TITLE
ENHANCEMENT Allow menu to be extendable from DNProject

### DIFF
--- a/code/model/DNProject.php
+++ b/code/model/DNProject.php
@@ -148,6 +148,33 @@ class DNProject extends DataObject {
 	}
 
 	/**
+	 * Get the menu to be shown on projects
+	 *
+	 * @return ArrayList
+	 */
+	public function Menu() {
+		$list = new ArrayList();
+
+		$list->push(new ArrayData(array(
+			'Link' => sprintf('naut/project/%s', $this->Name),
+			'Title' => 'Deploy',
+			'IsActive' => Controller::curr()->getAction() == 'project'
+		)));
+
+		if(Controller::curr()->FlagSnapshotsEnabled()) {
+			$list->push(new ArrayData(array(
+				'Link' => sprintf('naut/project/%s/snapshots', $this->Name),
+				'Title' => 'Snapshots',
+				'IsActive' => Controller::curr()->getAction() == 'snapshots'
+			)));
+		}
+
+		$this->extend('updateMenu', $list);
+
+		return $list;
+	}
+
+	/**
 	 * Restrict access to viewing this project
 	 *
 	 * @param Member $member

--- a/templates/Layout/DNRoot_environment.ss
+++ b/templates/Layout/DNRoot_environment.ss
@@ -5,10 +5,9 @@
 
 <% if $CurrentProject %>
 	<ul class="nav nav-tabs">
-		<li class="active"><a href="naut/project/$CurrentProject.Name">Deploy</a></li>
-		<% if $FlagSnapshotsEnabled %>
-			<li><a href="naut/project/$CurrentProject.Name/snapshots">Snapshots</a></li>
-		<% end_if %>
+		<% loop $CurrentProject.Menu %>
+		<li<% if $IsActive %> class="active"<% end_if %>><a href="$Link">$Title</a></li>
+		<% end_loop %>
 	</ul>
 <% end_if %>
 <ul class="nav level-2">

--- a/templates/Layout/DNRoot_project.ss
+++ b/templates/Layout/DNRoot_project.ss
@@ -4,10 +4,9 @@
 
 <% if $CurrentProject %>
 <ul class="nav nav-tabs">
-	<li<% if ProjectOverview %> class="active"<% end_if %>><a href="naut/project/$CurrentProject.Name">Deploy</a></li>
-	<% if $FlagSnapshotsEnabled %>
-		<li<% if SnapshotsSection %> class="active"<% end_if %>><a href="naut/project/$CurrentProject.Name/snapshots">Snapshots</a></li>
-	<% end_if %>
+	<% loop $CurrentProject.Menu %>
+	<li<% if $IsActive %> class="active"<% end_if %>><a href="$Link">$Title</a></li>
+	<% end_loop %>
 </ul>
 <% end_if %>
 


### PR DESCRIPTION
Allows an extension class to add their own menu items and to remove
existing ones if necessary.

I'm not happy about the `Controller::curr()` usage, so if there's a better
way of doing this, let me know :)