### PR TITLE
BUG Pipeline attempts to create backup if there's no deployed build

### DIFF
--- a/code/model/steps/DeploymentPipelineStep.php
+++ b/code/model/steps/DeploymentPipelineStep.php
@@ -104,7 +104,6 @@ class DeploymentPipelineStep extends LongRunningPipelineStep {
 	
 	/**
 	 * Create a snapshot of the db and store the ID on the Pipline
-	 * 
 	 * @return bool True if success
 	 */
 	protected function createSnapshot() {
@@ -119,7 +118,13 @@ class DeploymentPipelineStep extends LongRunningPipelineStep {
 			$this->log("[Skipped] Create DNDataTransfer backup");
 			return true;
 		}
-		
+
+		// Skip snapshot for environments with no build
+		if(!$this->Pipeline()->Environment()->CurrentBuild()) {
+			$this->log('[Skipped] No current build, skipping snapshot');
+			return true;
+		}
+
 		// create a snapshot
 		$pipeline = $this->Pipeline();
 		$job = DNDataTransfer::create();
@@ -148,7 +153,12 @@ class DeploymentPipelineStep extends LongRunningPipelineStep {
 			$this->log("[Skipped] Checking progress of snapshot backup");
 			return $this->startDeploy();
 		}
-		
+
+		// Skip snapshot for environments with no build
+		if(!$this->Pipeline()->Environment()->CurrentBuild()) {
+			return $this->startDeploy();
+		}
+
 		// Get related snapshot
 		$snapshot = $this->Pipeline()->PreviousSnapshot();
 		if(empty($snapshot) || !$snapshot->exists()) {

--- a/tests/PipelineTest.php
+++ b/tests/PipelineTest.php
@@ -244,6 +244,14 @@ class PipelineTest_DNDataTransfer extends DNDataTransfer implements TestOnly {
 	}
 }
 
+class PipelineTest_Project extends DNProject implements TestOnly {
+
+	public function repoExists() {
+		return false;
+	}
+
+}
+
 class PipelineTest_Environment extends DNEnvironment implements TestOnly {
 
 	/**

--- a/tests/PipelineTest.yml
+++ b/tests/PipelineTest.yml
@@ -11,14 +11,23 @@ Member:
     Email: test3@example.com
     FirstName: Jacob
     Surname: Marley
-DNProject:
+PipelineTest_Project:
   testproject:
     Name: 'testproject'
 PipelineTest_Environment:
   uat:
     Name: uat
-    Project: =>DNProject.testproject
+    Project: =>PipelineTest_Project.testproject
     Deployers: =>Member.deployer,=>Member.author
+  newenvironment:
+    Name: uat-new
+    Project: =>PipelineTest_Project.testproject
+    Deployers: =>Member.deployer,=>Member.author
+DNDeployment:
+  deploy-uat:
+    SHA: '123'
+    Status: 'Finished'
+    Environment: =>PipelineTest_Environment.uat
 Pipeline:
   testpipesmoketest:
     Author: =>Member.author


### PR DESCRIPTION
There's nothing to backup if nothing has been deployed yet.
In this case, the backup step should be skipped.