### PR TITLE
Sanitise the folder names with DNDataArchive consistently

### DIFF
--- a/code/model/DNDataArchive.php
+++ b/code/model/DNDataArchive.php
@@ -288,19 +288,12 @@ class DNDataArchive extends DataObject {
 	 */
 	public function generateFilename(DNDataTransfer $dataTransfer) {
 		$generator = new RandomGenerator();
-		$sanitizeRegex = array('/\s+/', '/[^a-zA-Z0-9-_\.]/');
-		$sanitizeReplace = array('/_/', '');
-		$envName = strtolower(preg_replace($sanitizeRegex, $sanitizeReplace, $this->OriginalEnvironment()->Name));
-		$projectName = strtolower(preg_replace(
-			$sanitizeRegex,
-			$sanitizeReplace,
-			$this->OriginalEnvironment()->Project()->Name
-		));
+		$filter = FileNameFilter::create();
 
 		return sprintf(
 			'%s-%s-%s-%s-%s',
-			$projectName,
-			$envName,
+			$filter->filter(strtolower($this->OriginalEnvironment()->Project()->Name)),
+			$filter->filter(strtolower($this->OriginalEnvironment()->Name)),
 			$dataTransfer->Mode,
 			date('Ymd'),
 			sha1($generator->generateEntropy())
@@ -317,15 +310,12 @@ class DNDataArchive extends DataObject {
 	public function generateFilepath(DNDataTransfer $dataTransfer) {
 		$data = DNData::inst();
 		$transferDir = $data->getDataTransferDir();
-		$sanitizeRegex = array('/\s+/', '/[^a-zA-Z0-9-_\.]/');
-		$sanitizeReplace = array('/_/', '');
-		$projectName = strtolower(preg_replace($sanitizeRegex, $sanitizeReplace, $this->OriginalEnvironment()->Project()->Name));
-		$envName = strtolower(preg_replace($sanitizeRegex, $sanitizeReplace, $this->OriginalEnvironment()->Name));
-		
+		$filter = FileNameFilter::create();
+
 		return sprintf('%s/%s/%s/transfer-%s/',
 			$transferDir,
-			$projectName,
-			$envName,
+			$filter->filter(strtolower($this->OriginalEnvironment()->Project()->Name)),
+			$filter->filter(strtolower($this->OriginalEnvironment()->Name)),
 			$dataTransfer->ID
 		);
 	}

--- a/tests/DNDataArchiveTest.php
+++ b/tests/DNDataArchiveTest.php
@@ -65,7 +65,7 @@ class DNDataArchiveTest extends DeploynautTest {
 
 		$filepath1 = $archive->generateFilepath($dataTransfer);
 		$this->assertNotNull($filepath1);
-		$this->assertContains('project_1', $filepath1);
+		$this->assertContains('project-1', $filepath1);
 		$this->assertContains('uat', $filepath1);
 		$this->assertContains('transfer-' . $dataTransfer->ID, $filepath1);
 	}
@@ -85,7 +85,7 @@ class DNDataArchiveTest extends DeploynautTest {
 
 		$filename = $archive->generateFilename($dataTransfer);
 		$this->assertNotNull($filename);
-		$this->assertContains('project_1', $filename);
+		$this->assertContains('project-1', $filename);
 		$this->assertContains('uat', $filename);
 		$this->assertContains('all', $filename);
 	}


### PR DESCRIPTION
Framework uses FileNameFilter for sanitising the folder names when
generating them from a value with special characters like spaces, etc,
but the current rules don't work as they replace spaces with underscores
and such. We should rely on FileNameFilter::filter() to do the
sanitising work for us instead of hardcoding those regex rules in
DNDataArchive.