### PR TITLE
FIX Permissions on DNDataArchives weren't creating unique cache keys.

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -1364,9 +1364,13 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	public function CompleteDataArchives() {
 		$project = $this->getCurrentProject();
 		$archives = new ArrayList();
-		foreach($project->DNEnvironmentList() as $env) {
-			foreach($env->DataArchives() as $archive) {
-				if($archive->canView() && !$archive->isPending()) $archives->push($archive);
+		
+		$archiveList = $project->Environments()->relation("DataArchives");
+		if($archiveList->count() > 0) {
+			foreach($archiveList as $archive) {
+				if($archive->canView() && !$archive->isPending()) {
+					$archives->push($archive);
+				}
 			}
 		}
 		return new PaginatedList($archives->sort("Created", "DESC"), $this->request);

--- a/code/model/DNDataArchive.php
+++ b/code/model/DNDataArchive.php
@@ -205,7 +205,7 @@ class DNDataArchive extends DataObject {
 	 * @return true if $member (or the currently logged in member if null) can upload this archive
 	 */
 	public function canRestore($member = null) {
-		$key = is_object($member) ? $member->ID : $member;
+		$key = (is_object($member) ? $member->ID : $member) . '-' . $this->ID;
 		if(!isset(self::$_cache_can_restore[$key])) {
 			self::$_cache_can_restore[$key] = $this->Environment()->canUploadArchive($member);
 		}
@@ -220,7 +220,7 @@ class DNDataArchive extends DataObject {
 	 * @return true if $member (or the currently logged in member if null) can download this archive
 	 */
 	public function canDownload($member = null) {
-		$key = is_object($member) ? $member->ID : $member;
+		$key = (is_object($member) ? $member->ID : $member) . '-' . $this->ID;
 		if(!isset(self::$_cache_can_download[$key])) {
 			self::$_cache_can_download[$key] = $this->Environment()->canDownloadArchive($member);
 		}

--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -403,7 +403,6 @@ class DNEnvironment extends DataObject {
 		if(!$member) return false; // Must be logged in to check permissions
 
 		if(Permission::checkMember($member, 'ADMIN')) return true;
-
 		return $this->ArchiveDownloaders()->byID($member->ID)
 			|| $member->inGroups($this->ArchiveDownloaderGroups());
 	}


### PR DESCRIPTION
This fixes permission checks for listing snapshots.