### PR TITLE
Adding checkbox "Backup existing data" in snapshot restore form.

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -935,15 +935,18 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 			}
 		}
 
-		$job = DNDataTransfer::create();
-		$job->EnvironmentID = $environment->ID;
-		$job->Direction = $data['Direction'];
-		$job->Mode = $data['Mode'];
-		$job->DataArchiveID = $dataArchive ? $dataArchive->ID : null;
-		$job->write();
-		$job->start();
+		$transfer = DNDataTransfer::create();
+		$transfer->EnvironmentID = $environment->ID;
+		$transfer->Direction = $data['Direction'];
+		$transfer->Mode = $data['Mode'];
+		$transfer->DataArchiveID = $dataArchive ? $dataArchive->ID : null;
+		if($data['Direction'] == 'push') {
+			$transfer->setBackupBeforePush(!empty($data['BackupBeforePush']));
+		}
+		$transfer->write();
+		$transfer->start();
 
-		return $this->redirect($job->Link());
+		return $this->redirect($transfer->Link());
 	}
 
 	/**
@@ -1050,7 +1053,8 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 				new HiddenField('Direction', false, 'push'),
 				new LiteralField('Warning', '<p class="text-warning"><strong>Warning:</strong> This restore will overwrite the data on the chosen environment below</p>'),
 				new DropdownField('EnvironmentID', 'Environment', $envs->map()),
-				new DropdownField('Mode', 'Transfer', $modesMap)
+				new DropdownField('Mode', 'Transfer', $modesMap),
+				new CheckboxField('BackupBeforePush', 'Backup existing data', '1')
 			),
 			new FieldList(
 				FormAction::create('doDataTransfer', 'Restore Data')->addExtraClass('btn')

--- a/code/jobs/DataTransferJob.php
+++ b/code/jobs/DataTransferJob.php
@@ -26,7 +26,7 @@ class DataTransferJob {
 		$environment = $dataTransfer->Environment();
 		$backupDataTransfer = null;
 
-		if($dataTransfer->Direction == 'push') {
+		if(!empty($this->args['backupBeforePush']) && $dataTransfer->Direction == 'push') {
 			$backupDataTransfer = DNDataTransfer::create();
 			$backupDataTransfer->EnvironmentID = $environment->ID;
 			$backupDataTransfer->Direction = 'get';

--- a/code/model/jobs/DNDataTransfer.php
+++ b/code/model/jobs/DNDataTransfer.php
@@ -69,7 +69,17 @@ class DNDataTransfer extends DataObject {
 			'title' => 'Direction',
 		),
 	);
-	
+
+	/**
+	 * When running the transfer, should a backup be performed before pushing the data?
+	 * @var bool
+	 */
+	protected $backupBeforePush = true;
+
+	public function setBackupBeforePush($value) {
+		$this->backupBeforePush = $value;
+	}
+
 	public function getTitle() {
 		return $this->dbObject('Created')->Nice() . " (Status: {$this->Status})";
 	}
@@ -100,12 +110,12 @@ class DNDataTransfer extends DataObject {
 				new ReadonlyField('ProjectName', 'Project', $this->Environment()->Project()->Name),
 				new ReadonlyField('EnvironmentName', 'Environment', $this->Environment()->Name),
 				new ReadonlyField(
-					'DataArchive', 
-					'Archive File', 
+					'DataArchive',
+					'Archive File',
 					sprintf(
 						'<a href="%s">%s</a>',
 						$this->DataArchive()->ArchiveFile()->AbsoluteURL,
-						$this->DataArchive()->ArchiveFile()->Filename	
+						$this->DataArchive()->ArchiveFile()->Filename
 					)
 				),
 			)
@@ -123,7 +133,8 @@ class DNDataTransfer extends DataObject {
 		$env = $this->Environment();
 		$args = array(
 			'dataTransferID' => $this->ID,
-			'logfile' => $this->logfile()
+			'logfile' => $this->logfile(),
+			'backupBeforePush' => $this->backupBeforePush
 		);
 
 		$log = $this->log();

--- a/css/deploynaut.css
+++ b/css/deploynaut.css
@@ -304,8 +304,13 @@ form.fields-wide .field label.left {
 	margin: 0 20px;
 }
 
+#Form_DataTransferRestoreForm div.checkbox {
+	padding-left: 15px;
+	padding-top: 5px;
+	float: right;
+}
 #Form_DataTransferRestoreForm .Actions {
-	margin-top: 40px;
+	margin-top: 35px;
 }
 
 #Form_MoveForm .Actions {


### PR DESCRIPTION
Determines whether to produce an automatic backup of the existing data
in the target environment before restoring the snapshot.

Here's what it looks like now:

![screen shot 2015-07-02 at 4 08 54 pm](https://cloud.githubusercontent.com/assets/138450/8469789/bfa854e4-20d4-11e5-8607-7d1430569c55.png)
