### PR TITLE
Re-purpose cleanup email to send emails in events of failure.

### DIFF
--- a/code/backends/CapistranoDeploymentBackend.php
+++ b/code/backends/CapistranoDeploymentBackend.php
@@ -54,33 +54,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			});
 
 			if(!$command->isSuccessful()) {
-				// Notify of failure via email, if possible.
-				$to = Config::inst()->get('DNRoot', 'alerts_to');
-				if(!$to) {
-					$log->write('Warning: cleanup has failed, but fine to continue. Needs manual cleanup sometime.');
-				} else {
-					$log->write('Warning: cleanup has failed, but fine to continue. Alert email sent.');
-
-					$subject = sprintf('[Deploynaut] Cleanup failure on %s', $name);
-					$email = new Email(null, $to, $subject);
-					$email->setTemplate('CapistranoDeploymentBackend_cleanup');
-
-					// Grab the last 3k characters, starting on a linebreak.
-					$breakpoint = strrpos($log->content(), "\n", -3000);
-					if($breakpoint === false) {
-						$content = $log->content();
-					} else {
-						$content = "[... log has been trimmed ...]\n" . substr($log->content(), $breakpoint+1);
-					}
-
-					$email->populateTemplate(array(
-						'ProjectName' => $project->Name,
-						'EnvironmentName' => $environment->Name,
-						'Log' => $content
-					));
-
-					$email->send();
-				}
+				$log->write('Warning: Cleanup failed, but fine to continue. Needs manual cleanup sometime.');
 			}
 		};
 
@@ -91,6 +65,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 
 		if(!$command->isSuccessful()) {
 			$cleanupFn();
+			$environment->sendFailureEmail($log);
 			throw new RuntimeException($command->getErrorOutput());
 		}
 
@@ -116,6 +91,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			$log->write($buffer);
 		});
 		if(!$command->isSuccessful()) {
+			$environment->sendFailureEmail($log);
 			throw new RuntimeException($command->getErrorOutput());
 		}
 		$log->write(sprintf('Maintenance page enabled on "%s"', $name));
@@ -131,6 +107,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			$log->write($buffer);
 		});
 		if(!$command->isSuccessful()) {
+			$environment->sendFailureEmail($log);
 			throw new RuntimeException($command->getErrorOutput());
 		}
 		$log->write(sprintf('Maintenance page disabled on "%s"', $name));
@@ -275,6 +252,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 				$log->write($buffer);
 			});
 			if(!$command->isSuccessful()) {
+				$environment->sendFailureEmail($log);
 				throw new RuntimeException($command->getErrorOutput());
 			}
 			$log->write(sprintf('Backup of database from "%s" done', $name));
@@ -288,6 +266,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 				$log->write($buffer);
 			});
 			if(!$command->isSuccessful()) {
+				$environment->sendFailureEmail($log);
 				throw new RuntimeException($command->getErrorOutput());
 			}
 			$log->write(sprintf('Backup of assets from "%s" done', $name));
@@ -366,6 +345,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			if(!$command->isSuccessful()) {
 				$cleanupFn();
 				$log->write(sprintf('Restore of database to "%s" failed: %s', $name, $command->getErrorOutput()));
+				$environment->sendFailureEmail($log);
 				throw new RuntimeException($command->getErrorOutput());
 			}
 			$log->write(sprintf('Restore of database to "%s" done', $name));
@@ -382,6 +362,7 @@ class CapistranoDeploymentBackend extends Object implements DeploymentBackend {
 			if(!$command->isSuccessful()) {
 				$cleanupFn();
 				$log->write(sprintf('Restore of assets to "%s" failed: %s', $name, $command->getErrorOutput()));
+				$environment->sendFailureEmail($log);
 				throw new RuntimeException($command->getErrorOutput());
 			}
 			$log->write(sprintf('Restore of assets to "%s" done', $name));

--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -26,7 +26,7 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 
 	/**
 	 * Optional email to use to alert about things that need some action to be performed,
-	 * such as cleanup after a failed task.
+	 * such as deployment failing or cleanup after a failed task.
 	 *
 	 * @config
 	 * @var string

--- a/templates/DeploymentFailureEmail.ss
+++ b/templates/DeploymentFailureEmail.ss
@@ -6,8 +6,7 @@
 <body>
 	<div class="body">
 		<p>Hi,</p>
-		<p>Latest deployment on <a href="$BaseHref/naut/project/$ProjectName/environment/$EnvironmentName/">
-			$ProjectName:$EnvironmentName</a> failed to remove old releases.</p>
+		<p>A command failed to execute correctly in <a href="$BaseHref/naut/project/{$Environment.Project.Name}/environment/{$Environment.Name}/">$FullName</a>.</p>
 		<p>Here is the tail of the log:</p>
 		<pre>$Log</pre>
 	</div>


### PR DESCRIPTION
Re-purpose this functionality to send an email in the event any
command has a failure for deployments, maintenance, or snapshots.

Note that `alerts_to` is not used by any of the current deploynaut projects
we're using at the moment, so it's fine to change how it works.