### PR TITLE
Provide a more specific name for the deployment environment.

### DIFF
--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -134,6 +134,10 @@ class DNEnvironment extends DataObject {
 		"PipelineCancellersList"	=> "Can Cancel List"
 	);
 
+	private static $singular_name = 'Capistrano Environment';
+
+	private static $plural_name = 'Capistrano Environments';
+
 	/**
 	 *
 	 * @var array


### PR DESCRIPTION
The default environment "DNEnvironment" only supports Capistrano
deployments, so name it after that purpose.

Mostly useful when you have a bunch of DNEnvironment subclasses that
have different backends, "D N Environment" (automatically singularised)
is not particularly informative.

Also relates to https://github.com/ss23/deploynaut-aws/pull/2 where I've changed
that one to use "Snowcake Environment" to be more specific as well.