### PR TITLE
Ensure that DeployJob catches any Exception, not just RuntimeException

### DIFF
--- a/code/jobs/DeployJob.php
+++ b/code/jobs/DeployJob.php
@@ -69,10 +69,10 @@ class DeployJob {
 				$DNProject,
 				isset($this->args['leaveMaintenacePage']) ? $this->args['leaveMaintenacePage'] : false
 			);
-		} catch(RuntimeException $exc) {
+		} catch(Exception $e) {
 			$this->updateStatus('Failed');
 			echo "[-] DeployJob failed" . PHP_EOL;
-			throw $exc;
+			throw $e;
 		}
 		echo "[-] DeployJob finished" . PHP_EOL;
 	}


### PR DESCRIPTION
We have some code that is throwing an exception that wasn't a
RuntimeException, but this didn't get caught.