### PR TITLE
added download attribute on snapshot download link to fix firefox bug

### DIFF
--- a/templates/Includes/CompleteArchiveList.ss
+++ b/templates/Includes/CompleteArchiveList.ss
@@ -44,7 +44,7 @@ If you would like to upload files from your computer to a new snapshot, click 'U
 						</td>
 						<td class="action">
 							<% if $CanDownload && ArchiveFile %>
-								<a href="$ArchiveFile.Link">
+								<a href="$ArchiveFile.Link" download="">
 									Download
 								</a>
 							<% end_if %>


### PR DESCRIPTION
On Firefox clicking on the download link for a snapshot opens up a new tab in the browser and doesn't download the file as expected. Adding the download attribute to the anchor tag makes it work in Firefox, leaving it empty retains the individual file names on download.