### PR TITLE
allow_web_editing true by default

### DIFF
--- a/_config/dnroot.yml
+++ b/_config/dnroot.yml
@@ -31,3 +31,5 @@ Injector:
     properties: 
       BaseDir: "../deploynaut-resources/build-cache"
       CacheSize: 5
+DNEnvironment:
+    allow_web_editing: true

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -170,6 +170,12 @@ To fix this, change to the deploy user and connect to the machine and answer yes
 
 	sudo su - www-data
 	ssh -p 2222 sites@192.168.0.1
+	
+Alternative to avoid the above is to add the code below to SSH config file /var/www/.ssh/config file of www-data user (not recommended)
+
+	Host *
+	 StrictHostKeyChecking no
+
 
 ## Capistrano roles
 
@@ -211,7 +217,7 @@ The [sspak](https://github.com/silverstripe/sspak) tool is required to create
 archives of the database/assets for a specific environment into an `*.sspak` file.
 This file can be used for backups, restores, and setting up local development environments.
 
-	wget --no-check-certificate https://raw.github.com/silverstripe/sspak/gh-pages/sspak.phar; sudo cp sspak.phar /usr/local/bin/sspak
+    curl -sS https://silverstripe.github.io/sspak/install | php -- /usr/local/bin
 
 Set up feature flags in `_ss_environment.php`:
 


### PR DESCRIPTION
I have given this some thought, either we allow_web_editing by default to be true or we refactor this code (https://github.com/silverstripe/deploynaut/blob/master/code/model/DNEnvironment.php#L902) so that, for the very first time when deploynaut is setup the administrator sees an option to  "create capistrano deploy configuration".  