### PR TITLE
DeploynautLogFile: Sanitise file name to avoid filesystem issues.

### DIFF
--- a/code/control/DeploynautLogFile.php
+++ b/code/control/DeploynautLogFile.php
@@ -7,12 +7,66 @@ class DeploynautLogFile {
 
 	protected $logFile;
 
-	public function __construct($logFile) {
-		$this->logFile = DEPLOYNAUT_LOG_PATH . '/' . $logFile;
+	protected $basePath;
+
+	/**
+	 * @param string $logfile The log filename
+	 * @param string|null $basePath Base path of where logs reside. Defaults to DEPLOYNAUT_LOG_PATH
+	 */
+	public function __construct($logFile, $basePath = null) {
+		$this->logFile = $logFile;
+		$this->basePath = $basePath ?: DEPLOYNAUT_LOG_PATH;
 	}
 
-	public function getLogFile() {
-		return $this->logFile;
+	/**
+	 * Set the log filename
+	 * @param string $filename
+	 */
+	public function setLogFile($filename) {
+		$this->logFile = $filename;
+	}
+
+	/**
+	 * Set the base path of where logs reside
+	 * @param string $path
+	 */
+	public function setBasePath($path) {
+		$this->basePath = $path;
+	}
+
+	/**
+	 * Return the un-sanitised log path.
+	 * @return string
+	 */
+	public function getRawFilePath() {
+		return $this->basePath . '/' . $this->logFile;
+	}
+
+	/**
+	 * Get the sanitised log path.
+	 * @return string
+	 */
+	public function getSanitisedLogFilePath() {
+		return $this->basePath . '/' . strtolower(FileNameFilter::create()->filter($this->logFile));
+	}
+
+	/**
+	 * Return log file path, assuming it exists. Returns NULL if nothing found.
+	 * @return string|null
+	 */
+	public function getLogFilePath() {
+		$path = $this->getSanitisedLogFilePath();
+
+		// for backwards compatibility on old logs
+		if(!file_exists($path)) {
+			$path = $this->getRawFilePath();
+
+			if(!file_exists($path)) {
+				return null;
+			}
+		}
+
+		return $path;
 	}
 
 	/**
@@ -20,8 +74,11 @@ class DeploynautLogFile {
 	 * @param string $message
 	 */
 	public function write($message) {
-		error_log('['.date('Y-m-d H:i:s').'] ' . $message .PHP_EOL, 3, $this->logFile);
-		@chmod($this->logFile, 0666);
+		// Make sure we write into the old path for existing logs. New logs use the sanitised file path instead.
+		$path = file_exists($this->getRawFilePath()) ? $this->getRawFilePath() : $this->getSanitisedLogFilePath();
+
+		error_log('['.date('Y-m-d H:i:s').'] ' . $message .PHP_EOL, 3, $path);
+		@chmod($path, 0666);
 	}
 
 	/**
@@ -29,7 +86,7 @@ class DeploynautLogFile {
 	 * @return bool
 	 */
 	public function exists() {
-		return file_exists($this->logFile);
+		return (bool) $this->getLogFilePath();
 	}
 
 	/**
@@ -37,7 +94,7 @@ class DeploynautLogFile {
 	 * @return string
 	 */
 	public function content() {
-		return $this->exists() ? file_get_contents($this->logFile) : 'Log has not been created yet.';
+		return $this->exists() ? file_get_contents($this->getLogFilePath()) : 'Log has not been created yet.';
 	}
 
 }

--- a/tests/DeploynautLogFileTest.php
+++ b/tests/DeploynautLogFileTest.php
@@ -1,0 +1,60 @@
+<?php
+class DeploynautLogFileTest extends SapphireTest {
+
+	protected $basePath;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->basePath = '/tmp/deploynautlogstest';
+		mkdir($this->basePath);
+	}
+
+	public function testLogFileNameSanitised() {
+		$log = new DeploynautLogFile('SomeSortOf Filename (UAT).log', $this->basePath);
+		$this->assertEquals($log->getSanitisedLogFilePath(), $this->basePath . '/somesortof-filename-uat.log');
+
+		$log = new DeploynautLogFile('..SomeSortOf Filename_(UAT).log', $this->basePath);
+		$this->assertEquals($log->getSanitisedLogFilePath(), $this->basePath . '/somesortof-filename-uat.log');
+
+		$log = new DeploynautLogFile('test-project.1823.log', $this->basePath);
+		$this->assertEquals($log->getSanitisedLogFilePath(), $this->basePath . '/test-project.1823.log');
+	}
+
+	public function testUnsanitisedLogFileFallback() {
+		touch($this->basePath . '/' . 'SomeSortOf Filename (UAT).log');
+
+		$log = new DeploynautLogFile('SomeSortOf Filename (UAT).log', $this->basePath);
+		$this->assertEquals($log->getLogFilePath(), $this->basePath . '/SomeSortOf Filename (UAT).log');
+		$this->assertTrue($log->exists());
+
+		// writing into the logs still works, and we reference the old file path still.
+		$log->write('Some test content');
+		$this->assertEquals($log->getLogFilePath(), $this->basePath . '/SomeSortOf Filename (UAT).log');
+		$this->assertContains('Some test content', $log->content());
+	}
+
+	public function testLogWriting() {
+		$log = new DeploynautLogFile('SomeSortOf Filename (UAT).log', $this->basePath);
+		$this->assertFalse($log->exists());
+		$this->assertNull($log->getLogFilePath());
+
+		$log->write('This is some content');
+		$this->assertTrue($log->exists());
+		$this->assertEquals($this->basePath . '/somesortof-filename-uat.log', $log->getLogFilePath());
+		$this->assertContains('This is some content', $log->content());
+	}
+
+	public function testLogDoesntExistMessage() {
+		$log = new DeploynautLogFile('SomeSortOf Filename (UAT).log', $this->basePath);
+		$this->assertNull($log->getLogFilePath());
+		$this->assertEquals('Log has not been created yet.', $log->content());
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		exec(sprintf('rm -rf %s', $this->basePath));
+	}
+
+}


### PR DESCRIPTION
This makes sure only alphanumeric, dashes, and dots are allowed to
make their way into the log filenames, and nothing else.

Uses FileNameFilter for the sanitisation job. If the old filename
is still being used, make sure we don't break the existing usage
of showing the old log file, as well as writing into it.