### PR TITLE
Work around bad-git-commit edge case.

### DIFF
--- a/code/model/jobs/DNDeployment.php
+++ b/code/model/jobs/DNDeployment.php
@@ -142,7 +142,11 @@ class DNDeployment extends DataObject {
 	public function getCommitMessage() {
 		$commit = $this->getCommit();
 		if($commit) {
-			return Convert::raw2xml($commit->getMessage());
+			try {
+				return Convert::raw2xml($commit->getMessage());
+			} catch(Gitonomy\Git\Exception\ReferenceNotFoundException $e) {
+				return null;
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
If the git commit is bad, the whole deployment screen fails.
This change minimises the impact of the error.