### PR TITLE
Multi step deploy

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -681,7 +681,7 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	 * @return \SS_HTTPResponse
 	 */
 	protected function beginPipeline($data, DeployForm $form, $isDryRun = false) {
-		$buildName = $form->getSelectedBuild($data);
+		$buildName = DeployForm::get_selected_build($data);
 
 		// Performs canView permission check by limiting visible projects
 		$project = $this->getCurrentProject();
@@ -891,10 +891,13 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	 *
 	 * @param array $data
 	 * @param DeployForm $form
-	 * @return \SS_HTTPResponse
+	 *
+	 * @return SS_HTTPResponse
+	 * @throws Exception
+	 * @throws ValidationException
 	 */
 	public function doDeploy($data, $form) {
-		$buildName = $form->getSelectedBuild($data);
+		$buildName = DeployForm::get_selected_build($data);
 
 		// Performs canView permission check by limiting visible projects
 		$project = $this->getCurrentProject();

--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -54,6 +54,7 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 		'pipelinelog',
 		'metrics',
 		'getDeployForm',
+		'doDeploy',
 		'deploy',
 		'deploylog',
 		'getDataTransferForm',
@@ -885,6 +886,52 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	}
 
 	/**
+	 * @param array $data
+	 * @param DeployForm $form
+	 *
+	 * @return string
+	 */
+	public function showDeploySummary(array $data, DeployForm $form) {
+
+		// Performs canView permission check by limiting visible projects
+		$project = $this->getCurrentProject();
+		if(!$project) {
+			return $this->project404Response();
+		}
+
+		// Performs canView permission check by limiting visible projects
+		$environment = $this->getCurrentEnvironment($project);
+		if(!$environment) {
+			return $this->environment404Response();
+		}
+
+		// get the selected build
+		$selectedBuild = DeployForm::get_selected_build($data);
+
+		$form->setFields(new FieldList(
+			new ReadonlyField('ReadonlySHA', 'Revision', $selectedBuild),
+			new HiddenField('SelectRelease', 'SelectRelease', 'SHA'),
+			new HiddenField('SHA', 'SHA', $selectedBuild)
+         ));
+
+		$form->setActions(new FieldList(
+			FormAction::create('doDeploy', "Deploy")
+				->addExtraClass('btn btn-primary deploy-button')
+				->setAttribute('data-environment-name', Convert::raw2att($environment->Name))
+		));
+		$form->enableSecurityToken();
+
+		$form->setFormAction($this->getRequest()->getURL());
+
+		$form->setTemplate('Form');
+		return $form->getController()->renderWith(
+			array('DNRoot_deploysummary', 'DNRoot'),
+			array("SummaryForm" => $form)
+		);
+	}
+
+
+	/**
 	 * Deployment form submission handler.
 	 *
 	 * Initiate a DNDeployment record and redirect to it for status polling
@@ -916,6 +963,7 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 		$this->extend('doDeploy', $project, $environment, $buildName, $data);
 
 		$sha = $project->DNBuildList()->byName($buildName);
+		/** @var DNDeployment $deployment */
 		$deployment = DNDeployment::create();
 		$deployment->EnvironmentID = $environment->ID;
 		$deployment->SHA = $sha->FullName();

--- a/code/control/DeployForm.php
+++ b/code/control/DeployForm.php
@@ -126,66 +126,92 @@ class DeployForm extends Form {
 	/**
 	 * @param DNRoot $controller
 	 * @param string $name
+	 * @param DNEnvironment $environment
+	 * @param DNProject $project
 	 */
 	public function __construct($controller, $name, DNEnvironment $environment, DNProject $project) {
 		if($environment->HasPipelineSupport()) {
-			// Determine if commits are filtered
-			$canBypass = Permission::check(DNRoot::DEPLOYNAUT_BYPASS_PIPELINE);
-			$canDryrun = $environment->DryRunEnabled && Permission::check(DNRoot::DEPLOYNAUT_DRYRUN_PIPELINE);
-			$commits = $environment->getDependentFilteredCommits();
-			if(empty($commits)) {
-				// There are no filtered commits, so show all commits
-				$field = $this->buildCommitSelector($project);
-				$validator = new DeployForm_CommitValidator();
-			} elseif($canBypass) {
-				// Build hybrid selector that allows users to follow pipeline or use any commit
-				$field = $this->buildCommitSelector($project, $commits);
-				$validator = new DeployForm_CommitValidator();
-			} else {
-				// Restrict user to only select pipeline filtered commits
-				$field = $this->buildPipelineField($commits);
-				$validator = new DeployForm_PipelineValidator();
-			}
-
-			// Generate actions allowed for this user
-			$actions = new FieldList(
-				FormAction::create('startPipeline', "Begin the release process on " . $environment->Name)
-					->addExtraClass('btn btn-primary')
-					->setAttribute('onclick', "return confirm('This will begin a release pipeline. Continue?');")
-			);
-			if($canDryrun) {
-				$actions->push(
-					FormAction::create('doDryRun', "Dry-run release process")
-						->addExtraClass('btn btn-info')
-						->setAttribute('onclick',
-							"return confirm('This will begin a release pipeline, but with the following exclusions:\\n" .
-							" - No messages will be sent\\n" .
-							" - No capistrano actions will be invoked\\n" .
-							" - No deployments or snapshots will be created.');"
-						)
-				);
-			}
-			if($canBypass) {
-				$actions->push(
-					FormAction::create('doDeploy', "Direct deployment (bypass pipeline)")
-						->addExtraClass('btn btn-warning')
-						->setAttribute('onclick',
-							"return confirm('This will start a direct deployment, bypassing the pipeline " .
-							"process in place.\\n\\nAre you sure this is necessary?');"
-						)
-				);
-			}
+			list($field, $validator, $actions) = $this->setupPipeline($environment, $project);
 		} else {
-			// without a pipeline simply allow any commit to be selected
-			$field = $this->buildCommitSelector($project);
-			$validator = new DeployForm_CommitValidator();
-			$actions = new FieldList(
-				FormAction::create('doDeploy', "Deploy to " . Convert::raw2att($environment->Name))
-					->addExtraClass('btn btn-primary deploy-button')
-					->setAttribute('data-environment-name', Convert::raw2att($environment->Name))
-			);
+			list($field, $validator, $actions) = $this->setupSimpleDeploy($environment, $project);
 		}
 		parent::__construct($controller, $name, new FieldList($field), $actions, $validator);
+	}
+
+	/**
+	 * @param DNEnvironment $environment
+	 * @param DNProject $project
+	 *
+	 * @return array
+	 */
+	protected function setupSimpleDeploy(DNEnvironment $environment, DNProject $project) {
+		// without a pipeline simply allow any commit to be selected
+		$field = $this->buildCommitSelector($project);
+		$validator = new DeployForm_CommitValidator();
+		$actions = new FieldList(
+			FormAction::create('showDeploySummary', "Go to summary")->addExtraClass('btn btn-primary')
+		);
+		return array($field, $validator, $actions);
+	}
+
+	/**
+	 * @param DNEnvironment $environment
+	 * @param DNProject $project
+	 *
+	 * @return array
+	 * @throws Exception
+	 */
+	protected function setupPipeline(DNEnvironment $environment, DNProject $project) {
+		// Determine if commits are filtered
+		$canBypass = Permission::check(DNRoot::DEPLOYNAUT_BYPASS_PIPELINE);
+		$canDryrun = $environment->DryRunEnabled && Permission::check(DNRoot::DEPLOYNAUT_DRYRUN_PIPELINE);
+		$commits = $environment->getDependentFilteredCommits();
+		if(empty($commits)) {
+			// There are no filtered commits, so show all commits
+			$field = $this->buildCommitSelector($project);
+			$validator = new DeployForm_CommitValidator();
+		} elseif($canBypass) {
+			// Build hybrid selector that allows users to follow pipeline or use any commit
+			$field = $this->buildCommitSelector($project, $commits);
+			$validator = new DeployForm_CommitValidator();
+		} else {
+			// Restrict user to only select pipeline filtered commits
+			$field = $this->buildPipelineField($commits);
+			$validator = new DeployForm_PipelineValidator();
+		}
+
+		// Generate actions allowed for this user
+		$actions = new FieldList(
+			FormAction::create('startPipeline', "Begin the release process on " . $environment->Name)
+				->addExtraClass('btn btn-primary')
+				->setAttribute('onclick', "return confirm('This will begin a release pipeline. Continue?');")
+		);
+		if($canDryrun) {
+			$actions->push(
+				FormAction::create('doDryRun', "Dry-run release process")
+					->addExtraClass('btn btn-info')
+					->setAttribute(
+						'onclick',
+						"return confirm('This will begin a release pipeline, but with the following exclusions:\\n" .
+						" - No messages will be sent\\n" .
+						" - No capistrano actions will be invoked\\n" .
+						" - No deployments or snapshots will be created.');"
+					)
+			);
+		}
+		if($canBypass) {
+			$actions->push(
+				FormAction::create('showDeploySummary', "Direct deployment (bypass pipeline)")
+					->addExtraClass('btn btn-warning')
+					->setAttribute(
+						'onclick',
+						"return confirm('This will start a direct deployment, bypassing the pipeline " .
+						"process in place.\\n\\nAre you sure this is necessary?');"
+					)
+			);
+			return array($field, $validator, $actions);
+		}
+		return array($field, $validator, $actions);
 	}
 
 	/**

--- a/code/control/DeployForm.php
+++ b/code/control/DeployForm.php
@@ -75,7 +75,7 @@ class DeployForm_CommitValidator extends DeployForm_ValidatorBase {
 
 		// Check sha
 		return $this->validateCommit(
-			$this->form->getSelectedBuild($data),
+			DeployForm::get_selected_build($data),
 			'SelectRelease'
 		);
 	}
@@ -92,7 +92,7 @@ class DeployForm_PipelineValidator extends DeployForm_ValidatorBase {
 
 	public function php($data) {
 		return $this->validateCommit(
-			$this->form->getSelectedBuild($data),
+			DeployForm::get_selected_build($data),
 			'FilteredCommits'
 		);
 	}
@@ -105,6 +105,23 @@ class DeployForm_PipelineValidator extends DeployForm_ValidatorBase {
  * @subpackage control
  */
 class DeployForm extends Form {
+
+	/**
+	 * Get the build selected from the given data
+	 *
+	 * @param array $data
+	 * @return string SHA of selected build
+	 */
+	public static function get_selected_build($data) {
+		if(isset($data['SelectRelease']) && !empty($data[$data['SelectRelease']])) {
+			// Filter out the tag/branch name if required
+			$array = explode('-', $data[$data['SelectRelease']]);
+			return reset($array);
+		}
+		if(isset($data['FilteredCommits']) && !empty($data['FilteredCommits'])) {
+			return $data['FilteredCommits'];
+		}
+	}
 
 	/**
 	 * @param DNRoot $controller
@@ -291,23 +308,6 @@ class DeployForm extends Form {
 			return DropdownField::create('FilteredCommits)', '')
 				->setEmptyString('No deployments available')
 				->performDisabledTransformation();
-		}
-	}
-
-	/**
-	 * Get the build selected from the given data
-	 *
-	 * @param array $data
-	 * @return string SHA of selected build
-	 */
-	public function getSelectedBuild($data) {
-		if(isset($data['SelectRelease']) && !empty($data[$data['SelectRelease']])) {
-			// Filter out the tag/branch name if required
-			$array = explode('-', $data[$data['SelectRelease']]);
-			return reset($array);
-		}
-		if(isset($data['FilteredCommits']) && !empty($data['FilteredCommits'])) {
-			return $data['FilteredCommits'];
 		}
 	}
 }

--- a/code/model/steps/DeploymentPipelineStep.php
+++ b/code/model/steps/DeploymentPipelineStep.php
@@ -12,7 +12,7 @@
  *     MaxDuration: 3600 # optionally timeout after 1 hour
  * </code>
  *
- * {@see DNRoot::doDeploy()} for non-pipeline equivalent
+ * {@see DNRoot::showDeploySummary()} for non-pipeline equivalent
  *
  * @property string $Doing
  *

--- a/css/deploynaut.css
+++ b/css/deploynaut.css
@@ -265,7 +265,7 @@ ul li pre {
 	border-bottom: 1px solid #eee;
 	padding: 8px 0;
 }
-#Form_DeployForm select, #Form_DeployForm input[type=text] {
+#DeployForm_DeployForm select, #DeployForm_DeployForm input[type=text] {
 	width: 450px;
 }
 
@@ -316,7 +316,7 @@ form.fields-wide .field label.left {
 	margin-top: 60px;
 }
 
-#Form_DeployForm .SelectionGroup {
+#DeployForm_DeployForm .SelectionGroup {
 	overflow: hidden;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -3174,90 +3174,90 @@ fieldset[disabled] a.btn, fieldset[disabled] a.action, fieldset[disabled] a.depl
     color: #3aaef9;
     background-color: #fff; }
 
-.btn-success, .deploy-form-outer .deploy-form *[name="action_doDeploy"] {
+.btn-success, .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] {
   color: #fff;
   background-color: #5cb85c;
   border-color: #4cae4c; }
   .btn-success:focus,
-  .deploy-form-outer .deploy-form [name="action_doDeploy"]:focus,
-  .btn-success.focus, .deploy-form-outer .deploy-form .focus[name="action_doDeploy"] {
+  .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:focus,
+  .btn-success.focus, .deploy-form-outer .deploy-form .focus[name="action_showDeploySummary"] {
     color: #fff;
     background-color: #449d44;
     border-color: #255625; }
-  .btn-success:hover, .deploy-form-outer .deploy-form [name="action_doDeploy"]:hover {
+  .btn-success:hover, .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:hover {
     color: #fff;
     background-color: #449d44;
     border-color: #398439; }
   .btn-success:active,
-  .deploy-form-outer .deploy-form [name="action_doDeploy"]:active,
+  .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:active,
   .btn-success.active,
-  .deploy-form-outer .deploy-form .active[name="action_doDeploy"],
-  .open > .btn-success.dropdown-toggle, .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_doDeploy"] {
+  .deploy-form-outer .deploy-form .active[name="action_showDeploySummary"],
+  .open > .btn-success.dropdown-toggle, .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_showDeploySummary"] {
     color: #fff;
     background-color: #449d44;
     border-color: #398439; }
     .btn-success:active:hover,
-    .deploy-form-outer .deploy-form [name="action_doDeploy"]:active:hover,
+    .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:active:hover,
     .btn-success:active:focus,
-    .deploy-form-outer .deploy-form [name="action_doDeploy"]:active:focus,
+    .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:active:focus,
     .btn-success:active.focus,
-    .deploy-form-outer .deploy-form [name="action_doDeploy"]:active.focus,
+    .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:active.focus,
     .btn-success.active:hover,
-    .deploy-form-outer .deploy-form .active[name="action_doDeploy"]:hover,
+    .deploy-form-outer .deploy-form .active[name="action_showDeploySummary"]:hover,
     .btn-success.active:focus,
-    .deploy-form-outer .deploy-form .active[name="action_doDeploy"]:focus,
+    .deploy-form-outer .deploy-form .active[name="action_showDeploySummary"]:focus,
     .btn-success.active.focus,
-    .deploy-form-outer .deploy-form .active.focus[name="action_doDeploy"],
+    .deploy-form-outer .deploy-form .active.focus[name="action_showDeploySummary"],
     .open > .btn-success.dropdown-toggle:hover,
-    .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_doDeploy"]:hover, .open > .btn-success.dropdown-toggle:focus,
-    .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_doDeploy"]:focus, .open > .btn-success.dropdown-toggle.focus, .deploy-form-outer .deploy-form .open > .dropdown-toggle.focus[name="action_doDeploy"] {
+    .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_showDeploySummary"]:hover, .open > .btn-success.dropdown-toggle:focus,
+    .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_showDeploySummary"]:focus, .open > .btn-success.dropdown-toggle.focus, .deploy-form-outer .deploy-form .open > .dropdown-toggle.focus[name="action_showDeploySummary"] {
       color: #fff;
       background-color: #398439;
       border-color: #255625; }
   .btn-success:active,
-  .deploy-form-outer .deploy-form [name="action_doDeploy"]:active,
+  .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:active,
   .btn-success.active,
-  .deploy-form-outer .deploy-form .active[name="action_doDeploy"],
-  .open > .btn-success.dropdown-toggle, .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_doDeploy"] {
+  .deploy-form-outer .deploy-form .active[name="action_showDeploySummary"],
+  .open > .btn-success.dropdown-toggle, .deploy-form-outer .deploy-form .open > .dropdown-toggle[name="action_showDeploySummary"] {
     background-image: none; }
   .btn-success.disabled,
-  .deploy-form-outer .deploy-form .disabled[name="action_doDeploy"],
+  .deploy-form-outer .deploy-form .disabled[name="action_showDeploySummary"],
   .btn-success.disabled:hover,
-  .deploy-form-outer .deploy-form .disabled[name="action_doDeploy"]:hover,
+  .deploy-form-outer .deploy-form .disabled[name="action_showDeploySummary"]:hover,
   .btn-success.disabled:focus,
-  .deploy-form-outer .deploy-form .disabled[name="action_doDeploy"]:focus,
+  .deploy-form-outer .deploy-form .disabled[name="action_showDeploySummary"]:focus,
   .btn-success.disabled.focus,
-  .deploy-form-outer .deploy-form .disabled.focus[name="action_doDeploy"],
+  .deploy-form-outer .deploy-form .disabled.focus[name="action_showDeploySummary"],
   .btn-success.disabled:active,
-  .deploy-form-outer .deploy-form .disabled[name="action_doDeploy"]:active,
+  .deploy-form-outer .deploy-form .disabled[name="action_showDeploySummary"]:active,
   .btn-success.disabled.active,
-  .deploy-form-outer .deploy-form .disabled.active[name="action_doDeploy"],
+  .deploy-form-outer .deploy-form .disabled.active[name="action_showDeploySummary"],
   .btn-success[disabled],
-  .deploy-form-outer .deploy-form [disabled][name="action_doDeploy"],
+  .deploy-form-outer .deploy-form [disabled][name="action_showDeploySummary"],
   .btn-success[disabled]:hover,
-  .deploy-form-outer .deploy-form [disabled][name="action_doDeploy"]:hover,
+  .deploy-form-outer .deploy-form [disabled][name="action_showDeploySummary"]:hover,
   .btn-success[disabled]:focus,
-  .deploy-form-outer .deploy-form [disabled][name="action_doDeploy"]:focus,
+  .deploy-form-outer .deploy-form [disabled][name="action_showDeploySummary"]:focus,
   .btn-success[disabled].focus,
-  .deploy-form-outer .deploy-form [disabled].focus[name="action_doDeploy"],
+  .deploy-form-outer .deploy-form [disabled].focus[name="action_showDeploySummary"],
   .btn-success[disabled]:active,
-  .deploy-form-outer .deploy-form [disabled][name="action_doDeploy"]:active,
+  .deploy-form-outer .deploy-form [disabled][name="action_showDeploySummary"]:active,
   .btn-success[disabled].active,
-  .deploy-form-outer .deploy-form [disabled].active[name="action_doDeploy"],
+  .deploy-form-outer .deploy-form [disabled].active[name="action_showDeploySummary"],
   fieldset[disabled] .btn-success,
-  fieldset[disabled] .deploy-form-outer .deploy-form *[name="action_doDeploy"],
-  .deploy-form-outer .deploy-form fieldset[disabled] *[name="action_doDeploy"], fieldset[disabled] .btn-success:hover,
-  fieldset[disabled] .deploy-form-outer .deploy-form [name="action_doDeploy"]:hover,
-  .deploy-form-outer .deploy-form fieldset[disabled] [name="action_doDeploy"]:hover, fieldset[disabled] .btn-success:focus,
-  fieldset[disabled] .deploy-form-outer .deploy-form [name="action_doDeploy"]:focus,
-  .deploy-form-outer .deploy-form fieldset[disabled] [name="action_doDeploy"]:focus, fieldset[disabled] .btn-success.focus,
-  fieldset[disabled] .deploy-form-outer .deploy-form .focus[name="action_doDeploy"],
-  .deploy-form-outer .deploy-form fieldset[disabled] .focus[name="action_doDeploy"], fieldset[disabled] .btn-success:active,
-  fieldset[disabled] .deploy-form-outer .deploy-form [name="action_doDeploy"]:active,
-  .deploy-form-outer .deploy-form fieldset[disabled] [name="action_doDeploy"]:active, fieldset[disabled] .btn-success.active, fieldset[disabled] .deploy-form-outer .deploy-form .active[name="action_doDeploy"], .deploy-form-outer .deploy-form fieldset[disabled] .active[name="action_doDeploy"] {
+  fieldset[disabled] .deploy-form-outer .deploy-form *[name="action_showDeploySummary"],
+  .deploy-form-outer .deploy-form fieldset[disabled] *[name="action_showDeploySummary"], fieldset[disabled] .btn-success:hover,
+  fieldset[disabled] .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:hover,
+  .deploy-form-outer .deploy-form fieldset[disabled] [name="action_showDeploySummary"]:hover, fieldset[disabled] .btn-success:focus,
+  fieldset[disabled] .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:focus,
+  .deploy-form-outer .deploy-form fieldset[disabled] [name="action_showDeploySummary"]:focus, fieldset[disabled] .btn-success.focus,
+  fieldset[disabled] .deploy-form-outer .deploy-form .focus[name="action_showDeploySummary"],
+  .deploy-form-outer .deploy-form fieldset[disabled] .focus[name="action_showDeploySummary"], fieldset[disabled] .btn-success:active,
+  fieldset[disabled] .deploy-form-outer .deploy-form [name="action_showDeploySummary"]:active,
+  .deploy-form-outer .deploy-form fieldset[disabled] [name="action_showDeploySummary"]:active, fieldset[disabled] .btn-success.active, fieldset[disabled] .deploy-form-outer .deploy-form .active[name="action_showDeploySummary"], .deploy-form-outer .deploy-form fieldset[disabled] .active[name="action_showDeploySummary"] {
     background-color: #5cb85c;
     border-color: #4cae4c; }
-  .btn-success .badge, .deploy-form-outer .deploy-form *[name="action_doDeploy"] .badge {
+  .btn-success .badge, .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] .badge {
     color: #5cb85c;
     background-color: #fff; }
 
@@ -3467,7 +3467,7 @@ fieldset[disabled] a.btn, fieldset[disabled] a.action, fieldset[disabled] a.depl
     color: #777777;
     text-decoration: none; }
 
-.btn-lg, .btn-group-lg > .btn, .btn-group-lg > .action, .btn-group-lg > .deploy-dropdown, .action, .deploy-dropdown, .deploy-form-outer .deploy-form *[name="action_doDeploy"] {
+.btn-lg, .btn-group-lg > .btn, .btn-group-lg > .action, .btn-group-lg > .deploy-dropdown, .action, .deploy-dropdown, .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] {
   padding: 10px 16px;
   font-size: 17px;
   line-height: 1.33333;
@@ -3485,20 +3485,20 @@ fieldset[disabled] a.btn, fieldset[disabled] a.action, fieldset[disabled] a.depl
   line-height: 1.5;
   border-radius: 0px; }
 
-.btn-block, .deploy-dropdown, .deploy-form-outer .deploy-form *[name="action_doDeploy"] {
+.btn-block, .deploy-dropdown, .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] {
   display: block;
   width: 100%; }
 
-.btn-block + .btn-block, .deploy-dropdown + .btn-block, .deploy-form-outer .deploy-form *[name="action_doDeploy"] + .btn-block, .btn-block + .deploy-dropdown, .deploy-dropdown + .deploy-dropdown, .deploy-form-outer .deploy-form *[name="action_doDeploy"] + .deploy-dropdown, .deploy-form-outer .deploy-form .btn-block + *[name="action_doDeploy"], .deploy-form-outer .deploy-form .deploy-dropdown + *[name="action_doDeploy"], .deploy-form-outer .deploy-form *[name="action_doDeploy"] + *[name="action_doDeploy"] {
+.btn-block + .btn-block, .deploy-dropdown + .btn-block, .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] + .btn-block, .btn-block + .deploy-dropdown, .deploy-dropdown + .deploy-dropdown, .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] + .deploy-dropdown, .deploy-form-outer .deploy-form .btn-block + *[name="action_showDeploySummary"], .deploy-form-outer .deploy-form .deploy-dropdown + *[name="action_showDeploySummary"], .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] + *[name="action_showDeploySummary"] {
   margin-top: 5px; }
 
 input[type="submit"].btn-block,
 input[type="submit"].deploy-dropdown,
-.deploy-form-outer .deploy-form input[type="submit"][name="action_doDeploy"],
+.deploy-form-outer .deploy-form input[type="submit"][name="action_showDeploySummary"],
 input[type="reset"].btn-block,
 input[type="reset"].deploy-dropdown,
-.deploy-form-outer .deploy-form input[type="reset"][name="action_doDeploy"],
-input[type="button"].btn-block, input[type="button"].deploy-dropdown, .deploy-form-outer .deploy-form input[type="button"][name="action_doDeploy"] {
+.deploy-form-outer .deploy-form input[type="reset"][name="action_showDeploySummary"],
+input[type="button"].btn-block, input[type="button"].deploy-dropdown, .deploy-form-outer .deploy-form input[type="button"][name="action_showDeploySummary"] {
   width: 100%; }
 
 .fade {
@@ -3783,7 +3783,7 @@ tbody.collapse.in {
   padding-left: 8px;
   padding-right: 8px; }
 
-.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle, .btn-group > .action + .dropdown-toggle, .btn-group > .deploy-dropdown + .dropdown-toggle, .deploy-form-outer .deploy-form .btn-group > *[name="action_doDeploy"] + .dropdown-toggle {
+.btn-group > .btn-lg + .dropdown-toggle, .btn-group-lg.btn-group > .btn + .dropdown-toggle, .btn-group > .action + .dropdown-toggle, .btn-group > .deploy-dropdown + .dropdown-toggle, .deploy-form-outer .deploy-form .btn-group > *[name="action_showDeploySummary"] + .dropdown-toggle {
   padding-left: 12px;
   padding-right: 12px; }
 
@@ -3797,11 +3797,11 @@ tbody.collapse.in {
 .btn .caret, .action .caret, .deploy-dropdown .caret {
   margin-left: 0; }
 
-.btn-lg .caret, .btn-group-lg > .btn .caret, .action .caret, .deploy-dropdown .caret, .deploy-form-outer .deploy-form *[name="action_doDeploy"] .caret {
+.btn-lg .caret, .btn-group-lg > .btn .caret, .action .caret, .deploy-dropdown .caret, .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] .caret {
   border-width: 5px 5px 0;
   border-bottom-width: 0; }
 
-.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .action .caret, .dropup .deploy-dropdown .caret, .dropup .deploy-form-outer .deploy-form *[name="action_doDeploy"] .caret, .deploy-form-outer .deploy-form .dropup *[name="action_doDeploy"] .caret {
+.dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .action .caret, .dropup .deploy-dropdown .caret, .dropup .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] .caret, .deploy-form-outer .deploy-form .dropup *[name="action_showDeploySummary"] .caret {
   border-width: 0 5px 5px; }
 
 .btn-group-vertical > .btn,
@@ -5756,7 +5756,7 @@ button.close {
     margin-bottom: 0; }
   .modal-footer .btn-group .btn + .btn, .modal-footer .btn-group .action + .btn, .modal-footer .btn-group .deploy-dropdown + .btn, .modal-footer .btn-group .btn + .action, .modal-footer .btn-group .action + .action, .modal-footer .btn-group .deploy-dropdown + .action, .modal-footer .btn-group .btn + .deploy-dropdown, .modal-footer .btn-group .action + .deploy-dropdown, .modal-footer .btn-group .deploy-dropdown + .deploy-dropdown {
     margin-left: -1px; }
-  .modal-footer .btn-block + .btn-block, .modal-footer .deploy-dropdown + .btn-block, .modal-footer .deploy-form-outer .deploy-form *[name="action_doDeploy"] + .btn-block, .deploy-form-outer .deploy-form .modal-footer *[name="action_doDeploy"] + .btn-block, .modal-footer .btn-block + .deploy-dropdown, .modal-footer .deploy-dropdown + .deploy-dropdown, .modal-footer .deploy-form-outer .deploy-form *[name="action_doDeploy"] + .deploy-dropdown, .deploy-form-outer .deploy-form .modal-footer *[name="action_doDeploy"] + .deploy-dropdown, .modal-footer .deploy-form-outer .deploy-form .btn-block + *[name="action_doDeploy"], .deploy-form-outer .deploy-form .modal-footer .btn-block + *[name="action_doDeploy"], .modal-footer .deploy-form-outer .deploy-form .deploy-dropdown + *[name="action_doDeploy"], .deploy-form-outer .deploy-form .modal-footer .deploy-dropdown + *[name="action_doDeploy"], .modal-footer .deploy-form-outer .deploy-form *[name="action_doDeploy"] + *[name="action_doDeploy"], .deploy-form-outer .deploy-form .modal-footer *[name="action_doDeploy"] + *[name="action_doDeploy"] {
+  .modal-footer .btn-block + .btn-block, .modal-footer .deploy-dropdown + .btn-block, .modal-footer .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] + .btn-block, .deploy-form-outer .deploy-form .modal-footer *[name="action_showDeploySummary"] + .btn-block, .modal-footer .btn-block + .deploy-dropdown, .modal-footer .deploy-dropdown + .deploy-dropdown, .modal-footer .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] + .deploy-dropdown, .deploy-form-outer .deploy-form .modal-footer *[name="action_showDeploySummary"] + .deploy-dropdown, .modal-footer .deploy-form-outer .deploy-form .btn-block + *[name="action_showDeploySummary"], .deploy-form-outer .deploy-form .modal-footer .btn-block + *[name="action_showDeploySummary"], .modal-footer .deploy-form-outer .deploy-form .deploy-dropdown + *[name="action_showDeploySummary"], .deploy-form-outer .deploy-form .modal-footer .deploy-dropdown + *[name="action_showDeploySummary"], .modal-footer .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] + *[name="action_showDeploySummary"], .deploy-form-outer .deploy-form .modal-footer *[name="action_showDeploySummary"] + *[name="action_showDeploySummary"] {
     margin-left: 0; }
 
 .modal-scrollbar-measure {
@@ -9941,13 +9941,13 @@ button.sidebar-open {
           .deploy-form-outer .deploy-form .SelectionGroup + .tab-content input[type="text"] > *,
           .deploy-form-outer .deploy-form .SelectionGroup + .tab-content .CompositeField > * {
             width: 100%; }
-    .deploy-form-outer .deploy-form *[name="action_doDeploy"] {
+    .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] {
       border-radius: 2px;
       font-size: 26px;
       line-height: 40px;
       margin: 20px 0; }
       @media (max-width: 992px) {
-        .deploy-form-outer .deploy-form *[name="action_doDeploy"] {
+        .deploy-form-outer .deploy-form *[name="action_showDeploySummary"] {
           font-size: 20px; } }
 
 .deploy-history {

--- a/javascript/deploynaut.js
+++ b/javascript/deploynaut.js
@@ -127,20 +127,16 @@
 			$(this).toggleClass( "open" );
 		});
 
-		if ($('#Form_DeployForm_BuildName').val() === '') {
-			$('#Form_DeployForm_action_doDeploy').attr('disabled', true);
+		if ($('#DeployForm_DeployForm_BuildName').val() === '') {
+			$('#DeployForm_DeployForm_action_showDeploySummary').attr('disabled', true);
 		}
 
-		$('#Form_DeployForm_BuildName').change(function() {
-			if ($('#Form_DeployForm_BuildName').val() === '') {
-				$('#Form_DeployForm_action_doDeploy').attr('disabled', true);
+		$('#DeployForm_DeployForm_BuildName').change(function() {
+			if ($('#DeployForm_DeployForm_BuildName').val() === '') {
+				$('#DeployForm_DeployForm_action_showDeploySummary').attr('disabled', true);
 				return;
 			}
-			$('#Form_DeployForm_action_doDeploy').attr('disabled', false);
-		});
-
-		$('#Form_DeployForm_action_doDeploy').click(function() {
-			return confirm('Are you sure that you want to deploy?');
+			$('#DeployForm_DeployForm_action_showDeploySummary').attr('disabled', false);
 		});
 
 		// Deployment screen
@@ -253,7 +249,7 @@
 			return false;
 		});
 
-		$('.deploy-form-outer').on('click', '.deploy-button', function(e) {
+		$('form').on('click', '.deploy-button', function(e) {
 			var releaseType = $(this).parents('form').find('input[name="SelectRelease"]').attr('value');
 
 			var environment = $(this).attr('data-environment-name');
@@ -307,7 +303,7 @@
 				}
 
 			}
-			
+
 			e.preventDefault();
 		});
 

--- a/sass/style.sass
+++ b/sass/style.sass
@@ -505,7 +505,7 @@ button.sidebar-open
 						width: 100%
 
 
-		*[name="action_doDeploy"]
+		*[name="action_showDeploySummary"]
 			@extend .btn-block
 			@extend .btn-lg
 			@extend .btn-success

--- a/templates/Layout/DNRoot_deploysummary.ss
+++ b/templates/Layout/DNRoot_deploysummary.ss
@@ -1,0 +1,22 @@
+<div class="content page-header">
+    <div class="row">
+        <div class="col-md-12">
+			<% include Breadcrumb %>
+			<% include DeploymentTabs %>
+			<% include ProjectLinks %>
+        </div>
+    </div>
+</div>
+
+<div class="content">
+
+    <div class="row">
+        <div class="col-md-12 environment-details">
+            <a href="$CurrentEnvironment.Link"><i class="fa fa-long-arrow-left"></i> Pick another revision</a>
+
+            <h4>Summary</h4>
+            $SummaryForm
+        </div>
+    </div>
+
+</div>


### PR DESCRIPTION
This PR separates the current single "select and deploy flow" into a two steps.

1) select revision
2) get a summary and deploy action

This is the first part of a series of refactorings that will enable a better communication between DNBackends and the user. 

This only affects simple deployments, not pipelined deployments