### PR TITLE
Ensure that all JS is forced to the bottom, not at the first script tag.

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -148,6 +148,11 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	 * Include requirements that deploynaut needs, such as javascript.
 	 */
 	public static function include_requirements() {
+
+		// JS should always go to the bottom, otherwise there's the risk that Requirements
+		// puts them halfway through the page to the nearest <script> tag. We don't want that.
+		Requirements::set_force_js_to_bottom(true);
+
 		Requirements::combine_files(
 			'deploynaut.js',
 			array(
@@ -155,6 +160,8 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 				'deploynaut/javascript/bootstrap.js',
 				'deploynaut/javascript/q.js',
 				'deploynaut/javascript/deploynaut.js',
+				'deploynaut/javascript/react-with-addons.min.js',
+				'deploynaut/javascript/deploy.js',
 				'deploynaut/javascript/bootstrap.file-input.js',
 				'deploynaut/thirdparty/select2/dist/js/select2.min.js',
 				'deploynaut/javascript/material.js',

--- a/javascript/deploy.js
+++ b/javascript/deploy.js
@@ -681,7 +681,7 @@ var SummaryLine = React.createClass({
 
 	render: function render() {
 		var from = "-",
-		    to = "-";
+			to = "-";
 
 		if (this.props.from !== null) {
 			from = this.props.from.substring(0, 30);
@@ -711,7 +711,13 @@ var SummaryLine = React.createClass({
 	}
 });
 
-/**
- * Render
- */
-React.render(React.createElement(DeployDropDown, { project_url: urls.project_url, env_url: urls.env_url, SecurityToken: security_token }), document.getElementById('deploy_form'));
+if (typeof urls != 'undefined') {
+	/**
+	 * Render
+	 */
+	React.render(React.createElement(DeployDropDown, {
+		project_url: urls.project_url,
+		env_url: urls.env_url,
+		SecurityToken: security_token
+	}), document.getElementById('deploy_form'));
+}

--- a/templates/Layout/DNRoot_environment.ss
+++ b/templates/Layout/DNRoot_environment.ss
@@ -87,9 +87,6 @@
                 }
 				var security_token = "{$SecurityID}";
             </script>
-			<script src="/deploynaut/javascript/react-with-addons.min.js"></script>
-            <script src="/deploynaut/javascript/deploy.js"></script>
-
 		<% end_if %>
 	<% end_if %>
 


### PR DESCRIPTION
This means we can now move the react and deploy.js dependencies into
combine_files() along with the rest of the JS.