### PR TITLE
Use a pagination summary instead of showing all pages

### DIFF
--- a/templates/Includes/Pagination.ss
+++ b/templates/Includes/Pagination.ss
@@ -8,7 +8,7 @@
                     </a>
                 </li>
 			<% end_if %>
-			<% loop $Pagination.Pages %>
+			<% loop $Pagination.PaginationSummary %>
 				<% if $CurrentBool %>
                     <li class="disabled"><a href="#">$PageNum</a></li>
 				<% else %>


### PR DESCRIPTION
Don't display all pages in the pagination, just show a simple summary

Before:
![image](https://cloud.githubusercontent.com/assets/485130/9723110/a863cd62-560e-11e5-9cd5-1d43d79cb430.png)

After:
![image](https://cloud.githubusercontent.com/assets/485130/9723112/c323f8fc-560e-11e5-9e3b-9d9c1bc562d6.png)
