### PR TITLE
Show currently deployed version in more clarity and consistency.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -10085,9 +10085,6 @@ button.sidebar-open {
   .environment-details h3 .fa, .environment-details h3 .icon-star, .environment-details h3 .deploy-dropdown .status-icon, .deploy-dropdown .environment-details h3 .status-icon, .environment-details h3 .deploy-form-outer .deploy-form .header.loading .status-icon, .deploy-form-outer .deploy-form .header.loading .environment-details h3 .status-icon, .environment-details h3 .deploy-form-loading .deploy-form .header.loading .status-icon, .deploy-form-loading .deploy-form .header.loading .environment-details h3 .status-icon {
     font-size: 14px;
     vertical-align: super; }
-  .environment-details .build-details span.git-sha,
-  .environment-details .build-details a.git-sha {
-    font-size: 14px; }
 
 .project-links {
   text-align: right;

--- a/sass/style.sass
+++ b/sass/style.sass
@@ -698,12 +698,6 @@ button.sidebar-open
 		font-size: 14px
 		vertical-align: super
 
-	.build-details
-
-		span.git-sha,
-		a.git-sha
-			font-size: 14px
-
 	ul
 		@extend .list-unstyled
 

--- a/templates/Includes/GitDetailedBuildReference.ss
+++ b/templates/Includes/GitDetailedBuildReference.ss
@@ -6,32 +6,32 @@
 	
 <div class="row">
 	<div class="col-md-6">
+		<h4>Currently deployed:</h4>
 		<ul class="build-details">
+			<li>
 			<% if $Environment.Project.RepositoryInterface.CommitURL %>
-				<li>
-					<% if $Tags %>
-						<% loop $Tags %>
-							<span class="deployment-tag">$Me</span>
-						<% end_loop %>
-					<% end_if %>
-					<a href="{$Environment.Project.RepositoryInterface.CommitURL}/{$SHA}" class="git-sha tooltip-hint">
-						$SHA.ShortHash
-					</a>
-					<% if $Committer %><span class="commit-message"> - $Message</span><% end_if %>
-				</li>
+				<% if $Tags %>
+					<% loop $Tags %>
+						<span class="deployment-tag">$Me</span>
+					<% end_loop %>
+				<% end_if %>
+				<a href="{$Environment.Project.RepositoryInterface.CommitURL}/{$SHA}" class="git-sha tooltip-hint">$SHA.ShortHash</a>
+				<span class="commit-message"> - $Message</span>
 			<% else %>
-				<li><span class="git-sha tooltip-hint">
+				<span class="git-sha tooltip-hint">
 					<% if $Tags %>
 						<% loop $Tags %>
 							<span class="deployment-tag">$Me</span>
 						<% end_loop %>
 					<% end_if %>
-					$SHA.ShortHash<% if $Committer %><span class="commit-message"> - $Message</span><% end_if %>
-				</span></li>
+					$SHA.ShortHash<span class="commit-message"> - $Message</span>
+				</span>
 			<% end_if %>
+			</li>
 
-			<li><span class="deploy-date">Deployed on $LastEdited.Nice</span></li>
-			<li><a href="$Environment.CurrentBuild.Link">View Deploy Log</a></li>
+			<li>
+				<span class="deploy-date">Deployed on $LastEdited.Nice</span>. <a href="$Environment.CurrentBuild.Link">View deploy log</a>
+			</li>
 		</ul>
 	</div>
 


### PR DESCRIPTION
Fixing template issue where "Committer" doesn't ever exist, and never
shows the commit message. Add a header "Currently deployed" to
make it a bit more consistent with the deploy screen.