### PR TITLE
BUG Fixing duplicate tags missing, and ordering of tags.

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -1072,6 +1072,7 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 			'field_data' => array(),
 			'advanced_opts' => $advanced
 		);
+
 		foreach($project->DNTagList()->setLimit(null) as $tag) {
 			$name = $tag->Name();
 			$data['field_data'][] = array(
@@ -1079,6 +1080,10 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 				'text' => sprintf("%s", $name)
 			);
 		}
+
+		// show newest tags first.
+		$data['field_data'] = array_reverse($data['field_data']);
+
 		$tabs[] = $data;
 
 		// Past deployments

--- a/code/model/DNCommit.php
+++ b/code/model/DNCommit.php
@@ -84,6 +84,14 @@ class DNCommit extends ViewableData {
 	}
 
 	/**
+	 * Return the full SHA of the commit.
+	 * @return string
+	 */
+	public function SHA() {
+		return htmlentities($this->commit->getHash());
+	}
+
+	/**
 	 * Return the first line of the commit message.
 	 * @return string
 	 */


### PR DESCRIPTION
If multiple tags point to the same revision, these get skipped due to
internally storing revisions by SHA.

Also, tags would show in the reverse order, this changes it so newer
tags appear first in tag listings in the deploy form.