### PR TITLE
Fix commit labels to show Yes/No

### DIFF
--- a/templates/Layout/DNRoot_project.ss
+++ b/templates/Layout/DNRoot_project.ss
@@ -40,9 +40,9 @@
 						</td>
 						<td class="text-center">
 							<% if $CanDeploy %>
-								<span class="label label-success">Enabled</span>
+								<span class="label label-success">Yes</span>
 							<% else %>
-								<span class="label label-danger">Disabled</span>
+								<span class="label label-danger">No</span>
 							<% end_if %>
 						</td>
 						<td class="text-center">


### PR DESCRIPTION
This allows them to fit better with the default table column name "Can you deploy?"

Before:
![Before screenshot](https://www.evernote.com/l/AM98KixEJRxP47-zaLupDq1K9KW_G9XKkccB/image.png)

After:
![After screenshot](https://www.evernote.com/l/AM8NiLw_fWtNL5b1P3lGZNn5WDgtcWHo5pgB/image.png)