### PR TITLE
When a project is deleted the deploy key should also be deleted.

### DIFF
--- a/code/model/DNProject.php
+++ b/code/model/DNProject.php
@@ -719,6 +719,11 @@ class DNProject extends DataObject {
 		if(file_exists($this->getProjectFolderPath()) && Config::inst()->get('DNEnvironment', 'allow_web_editing')) {
 			Filesystem::removeFolder($this->getProjectFolderPath());
 		}
+
+		// Delete the deploy key
+		if(file_exists($this->getKeyDir())) {
+			Filesystem::removeFolder($this->getKeyDir());
+		}
 	}
 
 	/**


### PR DESCRIPTION
Otherwise there are problems re-creating the key if you delete a project
then re-create the project with the same name.