### PR TITLE
Fix DNEnvironmentTest::testBackendIdentifierField()

### DIFF
--- a/tests/DNEnvironmentTest.php
+++ b/tests/DNEnvironmentTest.php
@@ -156,3 +156,12 @@ class DNEnvironmentTest extends DeploynautTest {
 		$this->assertNull($fields->dataFieldByName('BackendIdentifier'));
 	}
 }
+
+class BackendOne extends DemoDeploymentBackend implements TestOnly {
+
+}
+
+class BackendTwo extends DemoDeploymentBackend implements TestOnly  {
+
+}
+


### PR DESCRIPTION
Fixes:

```
1) DNEnvironmentTest::testBackendIdentifierField
ReflectionException: Class BackendOne does not exist
```