### PR TITLE
stop jumping to top of screen when checking deploy details from log

### DIFF
--- a/javascript/deploynaut.js
+++ b/javascript/deploynaut.js
@@ -8,7 +8,8 @@
 		$('[data-toggle="popover"]').popover()
 	});
 
-	$('#current-build-toggle').on('click', function() {
+	$('#current-build-toggle').on('click', function(evt) {
+		evt.stopPropagation();
 		$('.current-build-data').toggleClass('hide');
 		$(this).find('i').toggleClass('fa-caret-down').toggleClass('fa-caret-up');
 	});


### PR DESCRIPTION
If you scrolled down a bit on the deploy log screen and click the 'show details' it jumps to the top of the screen