### PR TITLE
Ensure that pipeline marks deployment as a failure

### DIFF
--- a/code/model/Pipeline.php
+++ b/code/model/Pipeline.php
@@ -611,7 +611,6 @@ class Pipeline extends DataObject implements PipelineData {
 		// Finish off the pipeline - rollback will only be triggered on a failed pipeline.
 		$this->Status = 'Failed';
 		$this->write();
-
 	}
 
 	/**
@@ -686,6 +685,13 @@ class Pipeline extends DataObject implements PipelineData {
 			$this->log("Pipeline failed, not running rollback (not configured or not applicable yet).");
 			$this->write();
 			if($notify) $this->sendMessage(self::ALERT_FAILURE);
+		}
+
+		// Regardless of whether a rollback succeeded or not, we consider the deployment a failure.
+		$deployment = $this->CurrentDeployment();
+		if ($deployment) {
+			$deployment->Status = 'Failed';
+			$deployment->write();
 		}
 	}
 

--- a/tests/RollbackStepTest.php
+++ b/tests/RollbackStepTest.php
@@ -72,6 +72,9 @@ class RollbackStepTest extends PipelineTest {
 		$this->assertEquals('Finished', $step->Status);
 		// confirm the maintenace page has been left up for a failed rollback
 		$this->assertFalse(PipelineTest_MockLog::has_message('Enabling maintenance page for failed rollback'));
+
+		// The deployment was considered a failure
+		$this->assertEquals('Failed', $pipeline->CurrentDeployment()->Status);
 	}
 
 	/**
@@ -155,5 +158,8 @@ class RollbackStepTest extends PipelineTest {
 
 		// Confirm that the maintenance page is not disabled
 		$this->assertNotLogged('Maintenance page disabled');
+
+		// The deployment was considered a failure
+		$this->assertEquals('Failed', $pipeline->CurrentDeployment()->Status);
 	}
 }


### PR DESCRIPTION
Even if it succeeded, a rollback could be triggered from a failing smoke
test or other step. In this case, the original deployment is considered
a failure, not successful.