### PR TITLE
NEW Make deploynaut admin the default admin tab

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,6 +1,8 @@
 ---
 Name: deploynautconfig
 ---
+AdminRootController:
+  default_panel: 'DNAdmin'
 DNProject:
   defaults:
     DiskQuotaMB: "1024"


### PR DESCRIPTION
This makes it so the deploynaut admin is the default section of the CMS to load when going to `/admin` in your browser