### PR TITLE
Fix password resets email

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -16,9 +16,6 @@ Injector:
   Finite\StateMachine\StateMachine:
     class: Finite\StateMachine\StateMachine
     type: prototype
-  Email:
-    class: Email
-    type: prototype
 StateMachineFactory:
   handlers:
     DNDeployment:


### PR DESCRIPTION
For some reason when the code asks for a Member_ForgotPasswordEmail::create() the injector always return the base class `Email`