### PR TITLE
Fix deployment approval email sending

### DIFF
--- a/code/control/DNDeploymentHandlers.php
+++ b/code/control/DNDeploymentHandlers.php
@@ -16,7 +16,7 @@ class DNDeploymentHandlers extends Object {
 			return false;
 		}
 
-		$email = Injector::inst()->get('Email');
+		$email = Email::create();
 		$email->setTo(sprintf('%s <%s>', $approver->Name, $approver->Email));
 		$email->replyTo(sprintf('%s <%s>', $deployer->Name, $deployer->Email));
 		$email->setSubject('Deployment has been submitted');

--- a/code/control/DeploynautLogFile.php
+++ b/code/control/DeploynautLogFile.php
@@ -15,7 +15,13 @@ class DeploynautLogFile {
 	 */
 	public function __construct($logFile, $basePath = null) {
 		$this->logFile = $logFile;
-		$this->basePath = $basePath ?: DEPLOYNAUT_LOG_PATH;
+		if($basePath !== null) {
+			$this->basePath = $basePath;
+		} else if(defined('DEPLOYNAUT_LOG_PATH')) {
+			$this->basePath = DEPLOYNAUT_LOG_PATH;
+		} else {
+			$this->basePath = sys_get_temp_dir();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Due to the fix for 0bb589a8f3f908ba9f91dc56e7c453c127e481ca using emails as
as service doesn't work anymore.

The test has been changed from a pure PHPUnit test case to a SapphireTest and
uses the DB and the TestMailer to check if email was sent.