### PR TITLE
when viewing old deployments, display the logs

### DIFF
--- a/js/_actions.js
+++ b/js/_actions.js
@@ -21,6 +21,11 @@ export function setActiveStep(id) {
 	return {type: SET_ACTIVE_STEP, id};
 }
 
+export const NEW_DEPLOYMENT = "NEW_DEPLOYMENT";
+export function newDeployment() {
+	return {type: NEW_DEPLOYMENT};
+}
+
 export const START_REPO_UPDATE = 'START_REPO_UPDATE';
 export function startRepoUpdate() {
 	return {
@@ -358,9 +363,7 @@ export function getDeployLog() {
 	return (dispatch, getState) => {
 		deployAPI.waitForSuccess(getState, `/log/${getState().deployment.id}`, 100, function(data) {
 			dispatch(succeedDeployLogUpdate(data));
-		})
-			.then(() => console.log('deploy done')); // eslint-disable-line no-console
-
+		});
 	};
 }
 
@@ -401,7 +404,10 @@ export function getDeployment(id) {
 	return (dispatch, getState) => {
 		dispatch(startGetDeployment());
 		return deployAPI.call(getState, `/show/${id}`, 'get')
-			.then(data => dispatch(succeedGetDeployment(data)))
+			.then(data => {
+				dispatch(succeedGetDeployment(data));
+				dispatch(getDeployLog());
+			})
 			.catch(err => dispatch(failGetDeployment(err)));
 	};
 }

--- a/js/_api.js
+++ b/js/_api.js
@@ -146,7 +146,9 @@ export function create(name) {
 				case 'Complete':
 					return data;
 				case 'Failed':
-					throw new Error("An error occurred");
+					return data;
+				case 'Submitted':
+					return data;
 				default:
 					return sleep(retry).then(() => waitForSuccess(getState, uri, 2 * retry, callback));
 			}

--- a/js/constants/deployment.js
+++ b/js/constants/deployment.js
@@ -1,0 +1,9 @@
+// This is a copy of the states of a DNDeployment
+export const STATE_NEW = 'New';
+export const STATE_SUBMITTED = 'Submitted';
+export const STATE_INVALID = 'Invalid';
+export const STATE_QUEUED = 'Queued';
+export const STATE_DEPLOYING = 'Deploying';
+export const STATE_ABORTING = 'Aborting';
+export const STATE_COMPLETED = 'Completed';
+export const STATE_FAILED = 'Failed';

--- a/js/containers/CurrentBuildStatus.jsx
+++ b/js/containers/CurrentBuildStatus.jsx
@@ -52,8 +52,8 @@ const mapStateToProps = function(state) {
 const mapDispatchToProps = function(dispatch) {
 	return {
 		onItemClick: function(id) {
-			dispatch(actions.getDeployment(id))
-				.then(dispatch(actions.openPlanDialog()));
+			return dispatch(actions.getDeployment(id))
+				.then(() => dispatch(actions.openPlanDialog()));
 		}
 	};
 };

--- a/js/containers/DeployHistory.jsx
+++ b/js/containers/DeployHistory.jsx
@@ -79,7 +79,7 @@ const mapDispatchToProps = function(dispatch) {
 	return {
 		onItemClick: function(id) {
 			dispatch(actions.getDeployment(id))
-				.then(dispatch(actions.openPlanDialog()));
+				.then(() => dispatch(actions.openPlanDialog()));
 		},
 		onPageClick: function(page) {
 			dispatch(actions.getDeployHistory(page));

--- a/js/containers/DeployModal.jsx
+++ b/js/containers/DeployModal.jsx
@@ -29,7 +29,7 @@ function calculateSteps(props) {
 		},
 		{
 			title: "Deployment Plan",
-			show: props.sha_selected,
+			show: props.sha_is_selected,
 			is_loading: props.is_loading[1],
 			is_finished: props.is_finished[1],
 			content: (
@@ -52,7 +52,7 @@ function calculateSteps(props) {
 		},
 		{
 			title: "Deployment",
-			show: props.sha_selected && props.can_deploy,
+			show: props.sha_is_selected && props.can_deploy,
 			is_loading: props.is_loading[3],
 			is_finished: props.is_finished[3],
 			content: (
@@ -129,8 +129,9 @@ const mapStateToProps = function(state) {
 		plan_success: deployPlanIsOk(),
 		messages: state.messages,
 		active_step: state.navigation.active,
-		sha_selected: (state.git.selected_ref !== ""),
-		can_deploy: (state.approval.approved || state.approval.bypassed)
+		sha_is_selected: (state.git.selected_ref !== ""),
+		can_deploy: isApproved(),
+		state: state.deployment.state
 	};
 };
 

--- a/js/containers/Deployment.jsx
+++ b/js/containers/Deployment.jsx
@@ -3,8 +3,23 @@ const ReactRedux = require('react-redux');
 
 const Deploy = require('./buttons/Deploy.jsx');
 
+const deployStates = require('../constants/deployment.js');
+
 const deployment = function(props) {
 	let approverName = "";
+
+	function shouldShowLogs() {
+		if (props.state === deployStates.STATE_NEW) {
+			return false;
+		}
+		if (props.state === deployStates.STATE_SUBMITTED) {
+			return false;
+		}
+		if (props.state === deployStates.STATE_INVALID) {
+			return false;
+		}
+		return props.deploy_log.length > 0;
+	}
 
 	if (props.approved_by && props.approved_by.name) {
 		approverName = props.approved_by.name;
@@ -22,7 +37,7 @@ const deployment = function(props) {
 	}
 
 	let logOutput = null;
-	if (props.deploy_log.length) {
+	if (shouldShowLogs()) {
 		let lines = Object.keys(props.deploy_log).map(function(key) {
 			return <div key={key}>{props.deploy_log[key]}</div>;
 		});
@@ -78,6 +93,7 @@ const mapStateToProps = function(state) {
 		deployment_estimate: state.plan.deployment_estimate,
 		selected_ref: state.git.selected_ref,
 		plan: state.plan,
+		state: state.deployment.state,
 		deploy_log: state.deployment.log,
 		error: state.deployment.error
 	};

--- a/js/containers/buttons/NewDeployPlan.jsx
+++ b/js/containers/buttons/NewDeployPlan.jsx
@@ -13,6 +13,7 @@ const mapStateToProps = function() {
 const mapDispatchToProps = function(dispatch) {
 	return {
 		onClick: function() {
+			dispatch(actions.newDeployment());
 			dispatch(actions.openPlanDialog());
 		}
 	};

--- a/js/reducers/approval.js
+++ b/js/reducers/approval.js
@@ -2,35 +2,40 @@ var _ = require('underscore');
 
 var actions = require('../_actions.js');
 
+const initialState = {
+
+	bypassed: false,
+	bypassed_time: "",
+
+	rejected: false,
+	rejected_time: "",
+
+	request_by: {id: 5, email: "fredrik@example.com", role: "Team Member", name: "Fredrik Fredriksson"},
+	request_sent: false,
+	request_sent_time: "",
+
+	approved: false,
+	approved_time: "",
+
+	approved_by: "",
+	approvers: [
+		{id: 1, email: "anders@example.com", role: "Release manager", name: "Anders Andersson"},
+		{id: 2, email: "bengt@example.com", role: "Release manager", name: "Bengt Bengtsson"},
+		{id: 3, email: "daniel@example.com", role: "Release manager", name: "Daniel Danielsson"},
+		{id: 4, email: "erik@example.com", role: "Release manager", name: "Erik Eriksson"}
+	],
+	is_loading: false
+};
+
 module.exports = function approval(state, action) {
 	if (typeof state === 'undefined') {
-		return {
-
-			bypassed: false,
-			bypassed_time: "",
-
-			rejected: false,
-			rejected_time: "",
-
-			request_by: {id: 5, email: "fredrik@example.com", role: "Team Member", name: "Fredrik Fredriksson"},
-			request_sent: false,
-			request_sent_time: "",
-
-			approved: false,
-			approved_time: "",
-
-			approved_by: "",
-			approvers: [
-				{id: 1, email: "anders@example.com", role: "Release manager", name: "Anders Andersson"},
-				{id: 2, email: "bengt@example.com", role: "Release manager", name: "Bengt Bengtsson"},
-				{id: 3, email: "daniel@example.com", role: "Release manager", name: "Daniel Danielsson"},
-				{id: 4, email: "erik@example.com", role: "Release manager", name: "Erik Eriksson"}
-			],
-			is_loading: false
-		};
+		return initialState;
 	}
 
 	switch (action.type) {
+		case actions.NEW_DEPLOYMENT:
+			return initialState;
+
 		case actions.SUCCEED_DEPLOYMENT_GET:
 			return _.assign({}, state, {
 				request_by: action.data.deployment.deployer,

--- a/js/reducers/deployment.js
+++ b/js/reducers/deployment.js
@@ -1,21 +1,26 @@
 var _ = require('underscore');
 
 var actions = require('../_actions.js');
+var deployStates = require('../constants/deployment.js');
+
+const initialState = {
+	is_loading: false,
+	enqueued: false,
+	id: "",
+	data: {},
+	log: [],
+	error: null,
+	state: deployStates.STATE_NEW
+};
 
 module.exports = function deployment(state, action) {
 	if (typeof state === 'undefined') {
-		return {
-			is_loading: false,
-			enqueued: false,
-			id: "",
-			data: {},
-			log: [],
-			status: "",
-			error: null
-		};
+		return initialState;
 	}
 
 	switch (action.type) {
+		case actions.NEW_DEPLOYMENT:
+			return initialState;
 		case actions.START_DEPLOYMENT_GET:
 			return _.assign({}, state, {
 				is_loading: true,
@@ -24,6 +29,8 @@ module.exports = function deployment(state, action) {
 		case actions.SUCCEED_DEPLOYMENT_GET:
 			return _.assign({}, state, {
 				is_loading: false,
+				id: action.data.deployment.id,
+				state: action.data.deployment.state,
 				data: action.data.deployment
 			});
 		case actions.START_DEPLOYMENT_ENQUEUE:
@@ -43,7 +50,7 @@ module.exports = function deployment(state, action) {
 		case actions.SUCCEED_DEPLOY_LOG_UPDATE:
 			return _.assign({}, state, {
 				log: action.data.message,
-				status: action.data.status,
+				state: action.data.status,
 				error: null
 			});
 		case actions.FAIL_DEPLOY_LOG_UPDATE:

--- a/js/reducers/git.js
+++ b/js/reducers/git.js
@@ -2,19 +2,27 @@ var _ = require('underscore');
 
 var actions = require('../_actions.js');
 
+const initialState = {
+	selected_type: "",
+	selected_ref: "",
+	selected_name: "",
+	is_fetching: false,
+	is_updating: false,
+	last_updated: 0,
+	list: []
+};
+
 module.exports = function git(state, action) {
 	if (typeof state === 'undefined') {
-		return {
-			selected_type: "",
-			selected_ref: "",
-			selected_name: "",
-			is_fetching: false,
-			is_updating: false,
-			last_updated: 0,
-			list: []
-		};
+		return initialState;
 	}
 	switch (action.type) {
+		case actions.NEW_DEPLOYMENT:
+			return _.assign({}, state, {
+				selected_type: "",
+				selected_ref: "",
+				selected_name: "",
+			});
 		case actions.SET_REVISION_TYPE:
 			return _.assign({}, state, {
 				selected_type: action.id,

--- a/js/reducers/messages.js
+++ b/js/reducers/messages.js
@@ -10,6 +10,8 @@ module.exports = function messages(state, action) {
 			return action.summary.messages;
 
 		// clear the messages on these actions
+		case actions.NEW_DEPLOYMENT:
+		case actions.START_DEPLOYMENT_GET:
 		case actions.SUCCEED_REPO_UPDATE:
 		case actions.SUCCEED_REVISIONS_GET:
 		case actions.SET_REVISION:

--- a/js/reducers/navigation.js
+++ b/js/reducers/navigation.js
@@ -10,6 +10,10 @@ module.exports = function navigation(state, action) {
 		};
 	}
 	switch (action.type) {
+		case actions.NEW_DEPLOYMENT:
+			return _.assign({}, state, {
+				active: 0
+			});
 		case actions.SET_OPEN_DIALOG:
 			return _.assign({}, state, {
 				open: true

--- a/js/reducers/plan.js
+++ b/js/reducers/plan.js
@@ -2,19 +2,24 @@ var _ = require('underscore');
 
 var actions = require('../_actions.js');
 
+const initialState = {
+	is_loading: false,
+	deployment_type: "",
+	deployment_estimate: "",
+	changes: {},
+	validation_code: "",
+	summary_of_changes: ""
+};
+
 module.exports = function plan(state, action) {
 	if (typeof state === 'undefined') {
-		return {
-			is_loading: false,
-			deployment_type: "",
-			deployment_estimate: "",
-			changes: {},
-			validation_code: "",
-			summary_of_changes: "" // fixup
-		};
+		return initialState;
 	}
 
 	switch (action.type) {
+		case actions.NEW_DEPLOYMENT:
+			return initialState;
+
 		case actions.START_SUMMARY_GET:
 			return _.assign({}, state, {
 				deployment_type: "",


### PR DESCRIPTION
This commit also includes fixes for:
- clicking the new deploy button would not clear out the previously shown deployment data
- open the modal after deployment data have been loaded
- clear out error and warning messages from previous deployments in the modal
- introduces a constants/deployment.js that is used for comparing the status of the deployment
- stop infinite fetching of deploy logs if deployment haven't started