### PR TITLE
fix bug in the git ref selector due to object vs array

### DIFF
--- a/code/control/GitDispatcher.php
+++ b/code/control/GitDispatcher.php
@@ -83,13 +83,12 @@ class GitDispatcher extends Dispatcher {
 	public function show(\SS_HTTPRequest $request) {
 		$refs = [];
 		$prevDeploys = [];
-		$order = 0;
 
 		$uatEnvironment = $this->project->DNEnvironmentList()->filter('Usage', 'UAT')->first();
 		$uatBuild = $uatEnvironment ? $uatEnvironment->CurrentBuild() : null;
 		if ($uatBuild && $uatBuild->exists()) {
 			$refs[self::REF_TYPE_FROM_UAT] = [
-				'id' => ++$order,
+				'id' => self::REF_TYPE_FROM_UAT,
 				'label' => 'Promote the version currently on UAT',
 				'description' => 'Promote the version currently on UAT',
 				'promote_build' => [
@@ -104,14 +103,14 @@ class GitDispatcher extends Dispatcher {
 		}
 
 		$refs[self::REF_TYPE_BRANCH] = [
-			'id' => ++$order,
+			'id' => self::REF_TYPE_BRANCH,
 			'label' => 'Branch version',
 			'description' => 'Deploy the latest version of a branch',
 			'list' => $this->getGitBranches($this->project)
 		];
 
 		$refs[self::REF_TYPE_TAG] = [
-			'id' => ++$order,
+			'id' => self::REF_TYPE_TAG,
 			'label' => 'Tag version',
 			'description' => 'Deploy a tagged release',
 			'list' => $this->getGitTags($this->project)
@@ -125,13 +124,13 @@ class GitDispatcher extends Dispatcher {
 			}
 		}
 		$refs[self::REF_TYPE_PREVIOUS] = [
-			'id' => ++$order,
+			'id' => self::REF_TYPE_PREVIOUS,
 			'label' => 'Redeploy a release that was previously deployed (to any environment)',
 			'description' => 'Deploy a previous release',
 			'list' => $prevDeploys
 		];
 		$refs[self::REF_TYPE_SHA] = [
-			'id' => ++$order,
+			'id' => self::REF_TYPE_SHA,
 			'label' => 'Deploy a specific SHA',
 			'description' => 'Deploy a specific SHA'
 		];

--- a/js/components/RadioList.jsx
+++ b/js/components/RadioList.jsx
@@ -10,12 +10,12 @@ function RadioList(props) {
 	var list = Object.keys(props.options).map(function(key, index) {
 		return (
 			<Radio
-				key={index}
+				key={props.options[key].id}
 				description={props.options[key].description}
 				name="type"
-				checked={props.value === index}
+				checked={props.value === props.options[key].id}
 				id={index}
-				onClick={() => props.onRadioClick(index, props.options[key])}
+				onClick={() => props.onRadioClick(props.options[key].id, props.options[key])}
 				disabled={props.disabled}
 			/>
 		);
@@ -29,7 +29,7 @@ function RadioList(props) {
 }
 
 RadioList.propTypes = {
-	options: React.PropTypes.arrayOf(React.PropTypes.shape({
+	options: React.PropTypes.objectOf(React.PropTypes.shape({
 		id: React.PropTypes.number.isRequired,
 		description: React.PropTypes.string.isRequired
 	}).isRequired).isRequired,

--- a/js/containers/GitRefSelector.jsx
+++ b/js/containers/GitRefSelector.jsx
@@ -53,7 +53,7 @@ function GitRefSelector(props) {
 }
 
 GitRefSelector.propTypes = {
-	types: React.PropTypes.array.isRequired,
+	types: React.PropTypes.object.isRequired,
 	selected_type: React.PropTypes.oneOfType([
 		React.PropTypes.string,
 		React.PropTypes.number

--- a/js/reducers/git.js
+++ b/js/reducers/git.js
@@ -9,7 +9,7 @@ const initialState = {
 	is_fetching: false,
 	is_updating: false,
 	last_updated: 0,
-	list: []
+	list: {}
 };
 
 module.exports = function git(state, action) {
@@ -71,16 +71,26 @@ module.exports = function git(state, action) {
 				is_fetching: true
 			});
 
-		case actions.SUCCEED_REVISIONS_GET:
+		case actions.SUCCEED_REVISIONS_GET: {
+			let listAsArray = action.list.refs;
+
+			// The backend returns a proper array if the 'key's are 0, 1, 2, 3
+			// but an object if the 'keys' are 1, 2, 3.. this will ensure that
+			// we only have to deal with an object.
+			if (action.list.refs.constructor === Array) {
+				listAsArray = _.assign({}, action.list.refs);
+			}
+			console.log(listAsArray);
 			return _.assign({}, state, {
 				is_fetching: false,
-				list: action.list.refs,
+				// we do this to force the list into an object, inc ase it's an array
+				list: listAsArray,
 				last_updated: action.received_at,
 				selected_type: "",
 				selected_ref: "",
 				selected_name: ""
 			});
-
+		}
 		case actions.FAIL_REVISIONS_GET:
 			return _.assign({}, state, {
 				is_fetching: false


### PR DESCRIPTION
The backend converts the git ref list into a proper json array if the 'key's in the git refs are 0, 1, 2, 3
but it will encode it as an object if the 'keys' are 1, 2, 3..

This reared it's ugly head in environments that did not have deploys from UAT to promote.