### PR TITLE
fix log and deploybutton bug in the deploy modal

### DIFF
--- a/js/_actions.js
+++ b/js/_actions.js
@@ -1,6 +1,7 @@
 // polyfills
 require('babel-polyfill');
 const api = require('./_api.js');
+const constants = require('./constants/deployment.js');
 
 const gitAPI = api.create('git');
 const planAPI = api.create('plan');
@@ -401,6 +402,10 @@ export function failDeployLogUpdate(err) {
 
 export function getDeployLog() {
 	return (dispatch, getState) => {
+		const currentState = getState().deployment.list[getState().deployment.id].state;
+		if (!constants.hasLogs(currentState)) {
+			return;
+		}
 		deployAPI.waitForSuccess(getState, `/log/${getState().deployment.id}`, 100, function(data) {
 			dispatch(succeedDeployLogUpdate(data));
 		});

--- a/js/_api.js
+++ b/js/_api.js
@@ -143,7 +143,8 @@ export function create(name) {
 				callback(data);
 			}
 			switch (data.status) {
-				case 'Complete' || 'Completed':
+				case 'Completed':
+				case 'Complete':
 					return data;
 				case 'Failed':
 					return data;

--- a/js/constants/deployment.js
+++ b/js/constants/deployment.js
@@ -7,3 +7,43 @@ export const STATE_DEPLOYING = 'Deploying';
 export const STATE_ABORTING = 'Aborting';
 export const STATE_COMPLETED = 'Completed';
 export const STATE_FAILED = 'Failed';
+
+export function hasLogs(deployState) {
+	if (deployState === STATE_NEW) {
+		return false;
+	}
+	if (deployState === STATE_SUBMITTED) {
+		return false;
+	}
+	if (deployState === STATE_INVALID) {
+		return false;
+	}
+	return true;
+}
+
+export function isDeploying(deployState) {
+	if (deployState === STATE_QUEUED) {
+		return true;
+	}
+	if (deployState === STATE_DEPLOYING) {
+		return true;
+	}
+	if (deployState === STATE_ABORTING) {
+		return true;
+	}
+	return false;
+}
+
+export function isDeployDone(deployState) {
+	if (deployState === STATE_COMPLETED) {
+		return true;
+	}
+	if (deployState === STATE_FAILED) {
+		return true;
+	}
+	return false;
+}
+
+export function hasDeployStarted(deployState) {
+	return isDeployDone(deployState) || isDeploying(deployState);
+}

--- a/js/containers/DeployModal.jsx
+++ b/js/containers/DeployModal.jsx
@@ -12,6 +12,7 @@ const Messages = require('../components/Messages.jsx');
 const Modal = require('../Modal.jsx');
 
 const actions = require('../_actions.js');
+const constants = require('../constants/deployment.js');
 
 function calculateSteps(props) {
 	return [
@@ -116,18 +117,23 @@ const mapStateToProps = function(state, ownProps) {
 		active_step = parseInt(window.location.hash.substring(1), 10);
 	}
 
+	let currentState = 'new';
+	if (typeof state.deployment.list[ownProps.params.id] !== 'undefined') {
+		currentState = state.deployment.list[ownProps.params.id].state;
+	}
+
 	return {
 		is_loading: [
 			state.git.is_loading || state.git.is_updating,
 			state.plan.is_loading,
 			state.approval.is_loading,
-			state.deployment.enqueued
+			constants.isDeploying(currentState)
 		],
 		is_finished: [
 			state.git.selected_ref !== "",
 			deployPlanIsOk(),
 			deployPlanIsOk() && isApproved(),
-			false
+			constants.isDeployDone(currentState)
 		],
 		is_open: typeof (ownProps.params.id) !== 'undefined' && ownProps.params.id !== null,
 		plan_success: deployPlanIsOk(),

--- a/js/containers/Deployment.jsx
+++ b/js/containers/Deployment.jsx
@@ -3,19 +3,11 @@ const ReactRedux = require('react-redux');
 
 const Deploy = require('./buttons/Deploy.jsx');
 
-const deployStates = require('../constants/deployment.js');
-
 const deployment = function(props) {
 	let approverName = "";
 
 	function shouldShowLogs() {
-		if (props.state === deployStates.STATE_NEW) {
-			return false;
-		}
-		if (props.state === deployStates.STATE_SUBMITTED) {
-			return false;
-		}
-		if (props.state === deployStates.STATE_INVALID) {
+		if (typeof props.deploy_log === 'undefined') {
 			return false;
 		}
 		return props.deploy_log.length > 0;
@@ -94,7 +86,7 @@ const mapStateToProps = function(state) {
 		selected_ref: state.git.selected_ref,
 		plan: state.plan,
 		state: state.deployment.state,
-		deploy_log: state.deployment.log,
+		deploy_log: state.deployment.logs[state.deployment.id],
 		error: state.deployment.error
 	};
 };

--- a/js/containers/buttons/Deploy.jsx
+++ b/js/containers/buttons/Deploy.jsx
@@ -2,8 +2,16 @@ var ReactRedux = require('react-redux');
 
 var actions = require('../../_actions.js');
 var Button = require('../../components/Button.jsx');
+const constants = require('../../constants/deployment.js');
 
 function canDeploy(state) {
+	let currentState = 'new';
+	if (typeof state.deployment.list[state.deployment.id] !== 'undefined') {
+		currentState = state.deployment.list[state.deployment.id].state;
+	}
+	if (constants.hasDeployStarted(currentState)) {
+		return false;
+	}
 	if (state.approval.enqueued) {
 		return false;
 	}

--- a/js/reducers/deployment.js
+++ b/js/reducers/deployment.js
@@ -8,11 +8,13 @@ const initialState = {
 	enqueued: false,
 	id: "",
 	data: {},
-	log: [],
+	// this is a "list" (actually an object) of deployment logs keyed by the deployment id
+	logs: {},
 	error: null,
+	selected: {},
 	state: deployStates.STATE_NEW,
-	// this is the "list" (actually an object) of all deployments that we fetched, updated etc keyed by their unique
-	// id.
+	// this is the "list" (actually an object) of all deployments that we fetched, updated etc keyed by the deployment
+	// id
 	list: {},
 	current_page: 1
 };
@@ -46,7 +48,6 @@ module.exports = function deployment(state, action) {
 				enqueued: false,
 				id: "",
 				data: {},
-				log: [],
 				error: null,
 				state: deployStates.STATE_NEW,
 			});
@@ -95,8 +96,11 @@ module.exports = function deployment(state, action) {
 			const newList = _.assign({}, state.list);
 			newList[action.data.deployment.id] = action.data.deployment;
 
+			const newLogList = _.assign({}, state.logs);
+			newLogList[action.data.deployment.id] = action.data.message;
+
 			return _.assign({}, state, {
-				log: action.data.message,
+				logs: newLogList,
 				state: action.data.status,
 				error: null,
 				list: newList


### PR DESCRIPTION
- only fetch logs for deployment that have started a deploy
- don't overwrite logs from previous deployments, but keep them
  in a list keyed by deploy id
- ensure that the modals loading and finished for step 4
  is using the deployment state to figure out what to show
- Don't show a deploy button if deployment have already started.