### PR TITLE
add timezone for users and use it in generating user facing timestamps

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -25,3 +25,9 @@ StateMachineFactory:
         DNDeploymentHandlers: onQueue
       abort:
         DNDeploymentHandlers: onAbort
+Member:
+  extensions:
+    - TimezoneMemberExtension
+Injector:
+  SS_Datetime:
+    class: SS_Datetimezone

--- a/code/SS_Datetimezone.php
+++ b/code/SS_Datetimezone.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Class SS_Datetimezone
+ *
+ * Adds customisable timezones to the nice method on {@link SS_Datetime}.
+ */
+class SS_Datetimezone extends SS_Datetime {
+	/**
+	* Returns the date in the raw SQL-format specific to a given timezone passed from the Member class, e.g. “2006-01-18 16:32:04”
+	*/
+	public function Format($format) {
+		if($this->value){
+			$date = new DateTime($this->value);
+			//if the current user has set a timezone that is not the default then use that
+			$member = Member::currentUser();
+			if ($member && $member->exists() && $member->Timezone && $member->Timezone != date_default_timezone_get()) {
+				$date->setTimezone(new DateTimeZone($member->Timezone));    
+			}
+			return $date->Format($format);
+		}
+	}
+}

--- a/code/extensions/TimezoneMemberExtension.php
+++ b/code/extensions/TimezoneMemberExtension.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Class TimezoneMemberExtension.
+ *
+ * Adds all available timezones as an optional field to SilverStripe {@link Member}.
+ */
+class TimezoneMemberExtension extends DataExtension {
+	private static $db = [
+		'Timezone' => 'Varchar(255)',
+	];
+
+	public function getTimezones() {
+		$timezones = timezone_identifiers_list();
+		return array_combine($timezones, $timezones);
+	}
+
+	public function updateCMSFields(FieldList $fields) {   
+		$fields->removeFieldFromTab('Root', 'Timezone');
+		$field = DropdownField::create(
+			'Timezone',
+			'Timezone',
+		  $this->getTimezones())->setEmptyString('For NZ, choose Pacific/Auckland');
+		$fields->addFieldToTab('Root.timezone', $field);
+		return $fields;
+	}
+
+}

--- a/code/model/DNBranch.php
+++ b/code/model/DNBranch.php
@@ -87,13 +87,10 @@ class DNBranch extends ViewableData {
 			//occasionally parsing will fail this is a fallback to make it still work
 			return new SS_Datetime();
 		}
-		// gitonomy sets the time to UTC, so now we set the timezone to
-		// whatever PHP is set to (date.timezone). This will change in the future if each
-		// deploynaut user has their own timezone
 
 		$created->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
-		$date = new SS_Datetime();
+		$date = SS_Datetime::create();
 		$date->setValue($created->format('Y-m-d H:i:s'));
 		$this->_lastUpdatedCache = $date;
 		return $date;

--- a/code/model/DNCommit.php
+++ b/code/model/DNCommit.php
@@ -196,12 +196,9 @@ class DNCommit extends ViewableData {
 	public function Created() {
 		$created = $this->commit->getCommitterDate();
 
-		// gitonomy sets the time to UTC, so now we set the timezone to
-		// whatever PHP is set to (date.timezone). This will change in the future if each
-		// deploynaut user has their own timezone
 		$created->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
-		$d = new SS_Datetime();
+		$d = SS_Datetime::create();
 		$d->setValue($created->format('Y-m-d H:i:s'));
 
 		return $d;

--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -49,7 +49,7 @@ class DNEnvironment extends DataObject {
 		"Name" => "Varchar(255)",
 		"URL" => "Varchar(255)",
 		"BackendIdentifier" => "Varchar(255)", // Injector identifier of the DeploymentBackend
-		"Usage" => "Enum('Production, UAT, Test, Unspecified', 'Unspecified')"
+		"Usage" => "Enum('Production, UAT, Test, Unspecified', 'Unspecified')",
 	];
 
 	/**

--- a/code/model/DNTag.php
+++ b/code/model/DNTag.php
@@ -53,13 +53,11 @@ class DNTag extends ViewableData {
 	public function Created() {
 		$created = $this->tag->getCommit()->getCommitterDate();
 
-		// gitonomy sets the time to UTC, so now we set the timezone to
-		// whatever PHP is set to (date.timezone). This will change in the future if each
-		// deploynaut user has their own timezone
 		$created->setTimezone(new DateTimeZone(date_default_timezone_get()));
 
-		$d = new SS_Datetime();
+		$d = SS_Datetime::create();
 		$d->setValue($created->format('Y-m-d H:i:s'));
+
 		return $d;
 	}
 


### PR DESCRIPTION
This adds the ability to make an `SS_Datetime` object that is timezone specific to what is defined in the logged in Member's settings.

The SS_Datetime objects already defined in `$db` across the code base should be redefined as `SS_Datetimezone` as we go along or as is appropriate for the front end users.
