### PR TITLE
Fixing gateway snapshots issues

### DIFF
--- a/ruby/data.rb
+++ b/ruby/data.rb
@@ -147,8 +147,6 @@ namespace :data do
 			if server[1]
 				ssh_command << "-p" << server[1]
 			end
-			ssh_command << "-l" << username
-			ssh_command << "-i" << fetch(:ssh_options)[:keys]
 			ssh_command << "-A"
 		end
 


### PR DESCRIPTION
 - Remove -l (user) option for gateway, it's already included in server string
 - Remove -i (identity) option, this file is not on the gateway server