### PR TITLE
Approval emails and fixes

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -1342,8 +1342,8 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 		$strategy = new DeploymentStrategy($environment);
 		$strategy->fromArray($request->requestVar('strategy'));
 		$deployment = $strategy->createDeployment();
-		// Skip through the approval state for now.
-		$deployment->getMachine()->apply(DNDeployment::TR_SUBMIT);
+		// Bypass approval by going straight to Approved, and then Queued.
+		$deployment->getMachine()->apply(DNDeployment::TR_APPROVE);
 		$deployment->getMachine()->apply(DNDeployment::TR_QUEUE);
 
 		return json_encode([

--- a/templates/email/DeploymentApprovalCancellationEmail.ss
+++ b/templates/email/DeploymentApprovalCancellationEmail.ss
@@ -1,0 +1,6 @@
+<p>Hi $Approver.FirstName,</p>
+
+<p>The approval of a <a href="$Link">deployment to $Environment.FullName</a> has been cancelled by {$Deployer.Name}. No further action is necessary.</p>
+
+<p>Kind regards,<br>
+SilverStripe Platform team</p>

--- a/templates/email/DeploymentApprovedEmail.ss
+++ b/templates/email/DeploymentApprovedEmail.ss
@@ -1,6 +1,6 @@
 <p>Hi $Deployer.FirstName,</p>
 
-<p>Good news! Your <a href="$Link">deployment to $Environment.FullName</a> has been approved by {$Approver.Name} and is now ready to proceed.</p>
+<p>Good news! {$Approver.Name} has approved your <a href="$Link">deployment to $Environment.FullName</a>.</p>
 
 <p>Kind regards,<br>
 SilverStripe Platform team</p>

--- a/templates/email/DeploymentRejectedEmail.ss
+++ b/templates/email/DeploymentRejectedEmail.ss
@@ -1,6 +1,6 @@
 <p>Hi $Deployer.FirstName,</p>
 
-<p>Unfortunately your <a href="$Link">deployment to $Environment.FullName</a> has been rejected by {$Approver.Name}.</p>
+<p>Unfortunately {$Approver.Name} has rejected your <a href="$Link">deployment to $Environment.FullName</a>.</p>
 
 <p>Please reply to this email to discuss directly with {$Approver.FirstName}.</p>
 

--- a/templates/email/DeploymentSubmittedEmail.ss
+++ b/templates/email/DeploymentSubmittedEmail.ss
@@ -1,6 +1,6 @@
 <p>Hi $Approver.FirstName,</p>
 
-<p>We're just letting you know that a <a href="$Link">deployment to $Environment.FullName</a> has been submitted by {$Deployer.Name}.</p>
+<p>We're just letting you know that {$Deployer.Name} has submitted a <a href="$Link">deployment to $Environment.FullName</a> for your approval.</p>
 
 <p>Summary of changes:</p>
 


### PR DESCRIPTION
 - Add cancellation email if someone cancelled deployment for approval
 - Tweak subject lines of emails to be more specific to user
 - Ensure approver is correct if approve/reject user was different
 - Don't send emails unless they transitioned from Submitted state
 - Fix old deploy from broken because of state machine changes