### PR TITLE
add getBaseDir and check/set before deploy via capistrano

### DIFF
--- a/code/backends/PackageGenerator.php
+++ b/code/backends/PackageGenerator.php
@@ -51,6 +51,9 @@ abstract class PackageGenerator {
 	public function getPackageFilename($identifier, $sha, $repositoryDir, DeploynautLogFile $log) {
 		// Fetch through the cache
 		if($this->cache) {
+			if (!$this->cache->getBaseDir()) {
+				$this->cache->setBaseDir("/var/www/mysite/deploynaut-resources/build-cache");
+			}
 			$identifier .= '-' . get_class($this) . '-' . $this->getIdentifier();
  			return $this->cache->getPackageFilename($this, $identifier, $sha, $repositoryDir, $log);
 

--- a/code/backends/SizeRestrictedPackageCache.php
+++ b/code/backends/SizeRestrictedPackageCache.php
@@ -32,6 +32,13 @@ class SizeRestrictedPackageCache implements PackageCache {
 	}
 
 	/**
+	 * @return mixed
+	 */
+	public function getBaseDir() {
+		return $this->baseDir;
+	}
+
+	/**
 	 * Return the filename of the generated package, retrieving from cache or generating as necessary
 	 *
 	 * @param PackageGenerator $generator The generator to use to create cache entries.


### PR DESCRIPTION
Currently causing capistrano deployments to fail when using PackageCache because basedir isn't being set.