### PR TITLE
Deploy options should be loaded from deployment data when needed

### DIFF
--- a/code/api/DeploynautAPIFormatter.php
+++ b/code/api/DeploynautAPIFormatter.php
@@ -50,6 +50,15 @@ class DeploynautAPIFormatter {
 			? ($deployment->ID === self::$_cache_current_build[$deployment->EnvironmentID]->ID)
 			: false;
 
+		$supportedOptions = $deployment->Environment()->Backend()->getDeployOptions($deployment->Environment());
+		$setOptions = $deployment->getDeploymentStrategy() ? $deployment->getDeploymentStrategy()->getOptions() : [];
+		$options = [];
+		foreach ($supportedOptions as $option) {
+			if (in_array($option->getName(), $setOptions)) {
+				$options[$option->getName()] = 'true';
+			}
+		}
+
 		return [
 			'id' => $deployment->ID,
 			'date_created' => $deployment->Created,
@@ -68,6 +77,7 @@ class DeploynautAPIFormatter {
 			'sha' => $deployment->SHA,
 			'short_sha' => substr($deployment->SHA, 0, 7),
 			'ref_type' => $deployment->RefType,
+			'options' => $options,
 			'commit_message' => $deployment->getCommitMessage(),
 			'commit_url' => $deployment->getCommitURL(),
 			'deployer' => $deployerData,

--- a/js/_actions.js
+++ b/js/_actions.js
@@ -189,10 +189,10 @@ export function updateRepoAndGetRevisions() {
 }
 
 export const TOGGLE_OPTION = 'TOGGLE_OPTION';
-export function toggleOption(id) {
+export function toggleOption(name) {
 	return {
 		type: TOGGLE_OPTION,
-		id: id
+		name: name
 	};
 }
 

--- a/js/containers/GitRefSelector.jsx
+++ b/js/containers/GitRefSelector.jsx
@@ -80,9 +80,9 @@ function GitRefSelector(props) {
 				<Checkbox
 					description={option.title}
 					name="option"
-					checked={props.selected_options[index] === 1}
+					checked={props.selected_options[option.name] === 'true'}
 					id={index}
-					onClick={() => props.onCheckboxClick(index)}
+					onClick={() => props.onCheckboxClick(option.name)}
 					disabled={props.disabled}
 				/>
 			</li>
@@ -166,8 +166,8 @@ const mapDispatchToProps = function(dispatch) {
 				dispatch(actions.getDeploySummary());
 			}
 		},
-		onCheckboxClick: function(id) {
-			dispatch(actions.toggleOption(id));
+		onCheckboxClick: function(name) {
+			dispatch(actions.toggleOption(name));
 			dispatch(actions.getDeploySummary());
 		},
 		onRefSelect: function(ref) {

--- a/js/reducers/git.js
+++ b/js/reducers/git.js
@@ -35,10 +35,10 @@ module.exports = function git(state, action) {
 			});
 		case actions.TOGGLE_OPTION:
 			let selected_options = state.selected_options;
-			if (selected_options[action.id] === 1) {
-				selected_options[action.id] = 0;
+			if (selected_options[action.name] === 'true') {
+				selected_options[action.name] = 'false';
 			} else {
-				selected_options[action.id] = 1;
+				selected_options[action.name] = 'true';
 			}
 			return _.assign({}, state, {
 				selected_options: selected_options
@@ -47,6 +47,7 @@ module.exports = function git(state, action) {
 			return _.assign({}, state, {
 				selected_ref: action.data.deployment.sha,
 				selected_type: action.data.deployment.ref_type,
+				selected_options: action.data.deployment.options
 			});
 		case actions.SET_REVISION: {
 			// get the 'nice' name of the commit, i.e the branch or tag name
@@ -97,8 +98,9 @@ module.exports = function git(state, action) {
 
 			let selected_options = [];
 			for (var i = 0; i < action.data.options.length; i++) {
-				if (action.data.options[i].defaultValue === true) {
-					selected_options[i] = 1;
+				const option = action.data.options[i];
+				if (option.defaultValue === true) {
+					selected_options[option.name] = 'true';
 				}
 			}
 


### PR DESCRIPTION
Don't use index as a way to identify the selected options, use name as
it comes back from the server in "option_name => (bool) true|false"
format.