### PR TITLE
make rollback button red so people do not push it

### DIFF
--- a/code/model/steps/EmergencyRollbackStep.php
+++ b/code/model/steps/EmergencyRollbackStep.php
@@ -154,13 +154,13 @@ class EmergencyRollbackStep extends LongRunningPipelineStep {
 		return array(
 			'rollback' => array(
 				'ButtonText' => _t('EmergencyRollbackStep.ROLLBACKBUTTON', 'Rollback'),
-				'ButtonType' => 'btn-success',
+				'ButtonType' => 'btn-danger',
 				'Link' => $this->Pipeline()->StepLink('rollback'),
 				'Title' => _t('EmergencyRollbackStep.ROLLBACKTHEDEPLOYMENTTITLE', 'Rollback the deployment')
 			),
 			'dismiss' => array(
 				'ButtonText' => _t('EmergencyRollbackStep.DISMISS', 'Dismiss'),
-				'ButtonType' => 'btn-info',
+				'ButtonType' => 'btn-success',
 				'Link' => $this->Pipeline()->StepLink('dismiss'),
 				'Title' => _t('EmergencyRollbackStep.ROLLBACKTHEDEPLOYMENTTITLE', 'Dismiss this option')
 			)


### PR DESCRIPTION
currently the rollback button is a nice inviting green and people click it because it's nice, inviting and green.

Let's make the Dismiss option green, and the rollback option scary

Current
![screen shot 2016-10-27 at 4 13 07 pm](https://cloud.githubusercontent.com/assets/11186642/19753538/f93f179c-9c61-11e6-8165-4af12c26eb58.png)

Changed
![screen shot 2016-10-27 at 4 20 07 pm](https://cloud.githubusercontent.com/assets/11186642/19753545/02aa6002-9c62-11e6-8583-6f03e6369fcd.png)

