### PR TITLE
Remove unncessary fetch of upcoming deployments

### DIFF
--- a/code/model/DNEnvironment.php
+++ b/code/model/DNEnvironment.php
@@ -300,7 +300,7 @@ class DNEnvironment extends DataObject {
 		// if no Viewers or ViewerGroups defined, fallback to DNProject::canView permissions
 		if ($this->Viewers()->exists() || $this->ViewerGroups()->exists()) {
 			return $this->Viewers()->byID($member->ID)
-			|| $member->inGroups($this->ViewerGroups());
+				|| $member->inGroups($this->ViewerGroups());
 		}
 
 		return $this->Project()->canView($member);
@@ -332,7 +332,7 @@ class DNEnvironment extends DataObject {
 		}
 
 		return $this->Deployers()->byID($member->ID)
-		|| $member->inGroups($this->DeployerGroups());
+			|| $member->inGroups($this->DeployerGroups());
 	}
 
 	/**
@@ -371,7 +371,7 @@ class DNEnvironment extends DataObject {
 		}
 
 		return $this->CanRestoreMembers()->byID($member->ID)
-		|| $member->inGroups($this->CanRestoreGroups());
+			|| $member->inGroups($this->CanRestoreGroups());
 	}
 
 	/**
@@ -406,7 +406,7 @@ class DNEnvironment extends DataObject {
 		}
 
 		return $this->CanBackupMembers()->byID($member->ID)
-		|| $member->inGroups($this->CanBackupGroups());
+			|| $member->inGroups($this->CanBackupGroups());
 	}
 
 	/**
@@ -445,7 +445,7 @@ class DNEnvironment extends DataObject {
 		}
 
 		return $this->ArchiveUploaders()->byID($member->ID)
-		|| $member->inGroups($this->ArchiveUploaderGroups());
+			|| $member->inGroups($this->ArchiveUploaderGroups());
 	}
 
 	/**
@@ -475,7 +475,7 @@ class DNEnvironment extends DataObject {
 		}
 
 		return $this->ArchiveDownloaders()->byID($member->ID)
-		|| $member->inGroups($this->ArchiveDownloaderGroups());
+			|| $member->inGroups($this->ArchiveDownloaderGroups());
 	}
 
 	/**
@@ -505,7 +505,7 @@ class DNEnvironment extends DataObject {
 		}
 
 		return $this->ArchiveDeleters()->byID($member->ID)
-		|| $member->inGroups($this->ArchiveDeleterGroups());
+			|| $member->inGroups($this->ArchiveDeleterGroups());
 	}
 
 	/**
@@ -680,33 +680,18 @@ class DNEnvironment extends DataObject {
 		// default / fallback sort order
 		$sort['LastEdited'] = 'DESC';
 
-		return $this->Deployments()
+		$deployments = $this->Deployments()
 			->where('"SHA" IS NOT NULL')
-			->filter('State', [
+			->sort($sort);
+
+		if (!$this->IsNewDeployEnabled()) {
+			$deployments = $deployments->filter('State', [
 				DNDeployment::STATE_COMPLETED,
 				DNDeployment::STATE_FAILED,
 				DNDeployment::STATE_INVALID
-			])
-			->sort($sort);
-	}
-
-	/**
-	 * A list of upcoming or current deployments.
-	 * @return ArrayList
-	 */
-	public function UpcomingDeployments() {
-		return $this->Deployments()
-			->where('"SHA" IS NOT NULL')
-			->filter('State', [
-				DNDeployment::STATE_NEW,
-				DNDeployment::STATE_SUBMITTED,
-				DNDeployment::STATE_APPROVED,
-				DNDeployment::STATE_REJECTED,
-				DNDeployment::STATE_ABORTING,
-				DNDeployment::STATE_QUEUED,
-				DNDeployment::STATE_DEPLOYING,
-			])
-			->sort('LastEdited DESC');
+			]);
+		}
+		return $deployments;
 	}
 
 	/**

--- a/js/EnvironmentOverview.jsx
+++ b/js/EnvironmentOverview.jsx
@@ -50,7 +50,6 @@ function Plan(props) {
 	store.dispatch(actions.setEnvironment(props.model.environment));
 	store.dispatch(actions.setUser(props.model.user));
 
-	store.dispatch(actions.getUpcomingDeployments());
 	store.dispatch(actions.getDeployHistory());
 	store.dispatch(actions.getRevisionsIfNeeded());
 	store.dispatch(actions.getApprovers());

--- a/js/_actions.js
+++ b/js/_actions.js
@@ -79,29 +79,6 @@ export function failRevisionsGet(err) {
 	};
 }
 
-export const START_UPCOMING_DEPLOYMENTS_GET = 'START_UPCOMING_DEPLOYMENTS_GET';
-export function startUpcomingDeploymentsGet() {
-	return {
-		type: START_UPCOMING_DEPLOYMENTS_GET
-	};
-}
-
-export const SUCCEED_UPCOMING_DEPLOYMENTS_GET = 'SUCCEED_UPCOMING_DEPLOYMENTS_GET';
-export function succeedUpcomingDeploymentsGet(data) {
-	return {
-		type: SUCCEED_UPCOMING_DEPLOYMENTS_GET,
-		data: data
-	};
-}
-
-export const FAIL_UPCOMING_DEPLOYMENTS_GET = 'FAIL_UPCOMING_DEPLOYMENTS_GET';
-export function failUpcomingDeploymentsGet(err) {
-	return {
-		type: FAIL_UPCOMING_DEPLOYMENTS_GET,
-		error: err
-	};
-}
-
 export const START_DEPLOY_HISTORY_GET = 'START_DEPLOY_HISTORY_GET';
 export function startDeployHistoryGet() {
 	return {
@@ -153,15 +130,6 @@ export function getDeployHistory() {
 		return deployAPI.call(getState, '/history', 'get')
 			.then(json => dispatch(succeedDeployHistoryGet(json)))
 			.catch(err => dispatch(failDeployHistoryGet(err)));
-	};
-}
-
-export function getUpcomingDeployments() {
-	return (dispatch, getState) => {
-		dispatch(startUpcomingDeploymentsGet());
-		return deployAPI.call(getState, '/upcoming', 'get')
-			.then(json => dispatch(succeedUpcomingDeploymentsGet(json)))
-			.catch(err => dispatch(failUpcomingDeploymentsGet(err)));
 	};
 }
 

--- a/js/containers/UpcomingDeployments.jsx
+++ b/js/containers/UpcomingDeployments.jsx
@@ -82,8 +82,7 @@ const mapStateToProps = function(state) {
 	});
 
 	return {
-		list: upcomingList,
-		error: state.deployment.upcoming_error
+		list: upcomingList
 	};
 };
 

--- a/js/reducers/deployment.js
+++ b/js/reducers/deployment.js
@@ -10,7 +10,6 @@ const initialState = {
 	// this is a "list" (actually an object) of deployment logs keyed by the deployment id
 	logs: {},
 	history_error: null,
-	upcoming_error: null,
 	error: null,
 	state: deployStates.STATE_NEW,
 	approval_is_loading: false,
@@ -46,10 +45,6 @@ module.exports = function deployment(state, action) {
 				history_is_loading: false,
 				history_error: action.error.toString()
 			});
-		case actions.FAIL_UPCOMING_DEPLOYMENTS_GET:
-			return _.assign({}, state, {
-				upcoming_error: action.error.toString()
-			});
 		case actions.SUCCEED_DEPLOY_HISTORY_GET: {
 			// get current list
 			const newList = _.assign({}, state.list);
@@ -60,20 +55,6 @@ module.exports = function deployment(state, action) {
 			return _.assign({}, state, {
 				list: newList,
 				history_is_loading: false
-			});
-		}
-		case actions.SUCCEED_UPCOMING_DEPLOYMENTS_GET: {
-			if (action.data.list.length === 0) {
-				return state;
-			}
-			// get current list
-			const newList = _.assign({}, state.list);
-			// add or update the entries in the current list
-			for (let i = 0; i < action.data.list.length; i++) {
-				newList[action.data.list[i].id] = action.data.list[i];
-			}
-			return _.assign({}, state, {
-				list: newList,
 			});
 		}
 		case actions.NEW_DEPLOYMENT:


### PR DESCRIPTION
The data can be filtered out of the deployment history

The front end is already setup to pick out the relevant deployments from the list of all deployments. This change will get rid of an unnecessary call to the backend.