### PR TITLE
state duplication cleanup

### DIFF
--- a/code/api/DeploynautAPIFormatter.php
+++ b/code/api/DeploynautAPIFormatter.php
@@ -34,8 +34,10 @@ class DeploynautAPIFormatter {
 		}
 		$approver = $deployment->Approver();
 		$approverData = null;
+		$approverID = "";
 		if ($approver && $approver->exists()) {
 			$approverData = $this->getStackMemberData($project, $approver);
+			$approverID = $approver->ID;
 		}
 
 		// failover for older deployments
@@ -106,6 +108,7 @@ class DeploynautAPIFormatter {
 			'commit_message' => $deployment->getCommitMessage(),
 			'commit_url' => $deployment->getCommitURL(),
 			'deployer' => $deployerData,
+			'approver_id' => $approverID,
 			'approver' => $approverData,
 			'state' => $deployment->State,
 			'is_current_build' => $isCurrentBuild

--- a/js/_actions.js
+++ b/js/_actions.js
@@ -295,9 +295,10 @@ export function failApprovalSubmit(err) {
 export function submitForApproval() {
 	return (dispatch, getState) => {
 		dispatch(startApprovalSubmit());
+		const current = getState().deployment.list[getState().deployment.current_id] || {};
 		return approvalsAPI.call(getState, '/submit', 'post', {
-			id: getState().deployment.id,
-			approver_id: getState().deployment.approver_id,
+			id: getState().deployment.current_id,
+			approver_id: current.approver_id,
 			title: getState().plan.title,
 			summary: getState().plan.summary_of_changes
 		})
@@ -333,7 +334,7 @@ export function cancelApprovalRequest() {
 	return (dispatch, getState) => {
 		dispatch(startApprovalCancel());
 		return approvalsAPI.call(getState, '/cancel', 'post', {
-			id: getState().deployment.id
+			id: getState().deployment.current_id
 		})
 			.then(function(data) {
 				dispatch(succeedApprovalCancel(data));
@@ -367,7 +368,7 @@ export function approveDeployment() {
 	return (dispatch, getState) => {
 		dispatch(startApprovalApprove());
 		return approvalsAPI.call(getState, '/approve', 'post', {
-			id: getState().deployment.id,
+			id: getState().deployment.current_id,
 			title: getState().plan.title,
 			summary: getState().plan.summary_of_changes
 		})
@@ -402,9 +403,10 @@ export function failApprovalReject(err) {
 export function rejectDeployment() {
 	return (dispatch, getState) => {
 		dispatch(startApprovalReject());
+		const current = getState().deployment.list[getState().deployment.current_id] || {};
 		return approvalsAPI.call(getState, '/reject', 'post', {
-			id: getState().deployment.id,
-			rejected_reason: getState().deployment.rejected_reason
+			id: getState().deployment.current_id,
+			rejected_reason: current.rejected_reason
 		})
 			.then(function(data) {
 				dispatch(succeedApprovalReject(data));
@@ -436,7 +438,7 @@ export function failDeploymentCreate(err) {
 
 export function createDeployment() {
 	return (dispatch, getState) => {
-		if (getState().deployment.id) {
+		if (getState().deployment.current_id) {
 			return Promise.resolve();
 		}
 
@@ -448,6 +450,7 @@ export function createDeployment() {
 		});
 
 		dispatch(startDeploymentCreate());
+		const current = getState().deployment.list[getState().deployment.current_id] || {};
 		return deployAPI.call(getState, '/createdeployment', 'post', {
 			ref: getState().git.selected_ref,
 			ref_type: getState().git.selected_type,
@@ -455,7 +458,7 @@ export function createDeployment() {
 			options: options,
 			title: getState().plan.title,
 			summary: getState().plan.summary_of_changes,
-			approver_id: getState().deployment.approver_id
+			approver_id: current.approver_id
 		})
 			.then(function(data) {
 				return dispatch(succeedDeploymentCreate(data));
@@ -503,10 +506,11 @@ export function failDeployLogUpdate(err) {
 
 export function getDeployLog() {
 	return (dispatch, getState) => {
-		if (!constants.hasLogs(getState().deployment.state)) {
+		const current = getState().deployment.list[getState().deployment.current_id] || {};
+		if (!constants.hasLogs(current.state)) {
 			return;
 		}
-		deployAPI.call(getState, `/log/${getState().deployment.id}`, 'get').then(data => {
+		deployAPI.call(getState, `/log/${getState().deployment.current_id}`, 'get').then(data => {
 			dispatch(succeedDeployLogUpdate(data));
 		});
 	};
@@ -516,7 +520,7 @@ export function startDeploy() {
 	return (dispatch, getState) => {
 		dispatch(startDeploymentEnqueue());
 		return deployAPI.call(getState, '/start', 'post', {
-			id: getState().deployment.id
+			id: getState().deployment.current_id
 		})
 			.then(function(data) {
 				return dispatch(succeedDeploymentEnqueue(data));
@@ -596,7 +600,7 @@ export function deleteDeployment() {
 	return (dispatch, getState) => {
 		dispatch(startDeploymentDelete());
 		return deployAPI.call(getState, '/delete', 'post', {
-			id: getState().deployment.id
+			id: getState().deployment.current_id
 		})
 			.then(function(data) {
 				return dispatch(succeedDeploymentDelete(data));

--- a/js/constants/deployment.js
+++ b/js/constants/deployment.js
@@ -82,6 +82,10 @@ export function isRejected(deployState) {
 	return deployState === STATE_REJECTED;
 }
 
+export function isQueued(deployState) {
+	return deployState === STATE_QUEUED;
+}
+
 export function canDelete(state) {
 	if (hasDeployStarted(state)) {
 		return false;
@@ -90,16 +94,17 @@ export function canDelete(state) {
 }
 
 export function canEdit(state) {
-	if (state.deployment.submitted) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
+	if (isSubmitted(current.state)) {
 		return false;
 	}
-	if (state.deployment.approved) {
+	if (isApproved(current.state)) {
 		return false;
 	}
-	if (state.deployment.rejected) {
+	if (isRejected(current.state)) {
 		return false;
 	}
-	if (state.deployment.queued) {
+	if (isQueued(current.state)) {
 		return false;
 	}
 	return true;

--- a/js/containers/Approval.jsx
+++ b/js/containers/Approval.jsx
@@ -7,6 +7,7 @@ const Bypass = require('./buttons/Bypass.jsx');
 const LoadingBar = require('../components/LoadingBar.jsx');
 
 const actions = require('../_actions.js');
+const constants = require('../constants/deployment.js');
 
 function Approval(props) {
 	var sentTime = null;
@@ -54,14 +55,14 @@ function Approval(props) {
 	);
 }
 
-function isDisabled(state) {
-	if (state.deployment.approved) {
+function isDisabled(deployState) {
+	if (constants.isApproved(deployState)) {
 		return true;
 	}
-	if (state.deployment.rejected) {
+	if (constants.isRejected(deployState)) {
 		return true;
 	}
-	if (state.deployment.queued) {
+	if (constants.isQueued(deployState)) {
 		return true;
 	}
 	return false;
@@ -75,11 +76,12 @@ const mapStateToProps = function(state) {
 		};
 	});
 
+	const current = state.deployment.list[state.deployment.current_id] || {};
 	return {
-		disabled: isDisabled(state),
-		date_requested_nice: state.deployment.data.date_requested_nice,
+		disabled: isDisabled(current.state),
+		date_requested_nice: current.date_requested_nice,
 		approvers: approvers,
-		approver_id: state.deployment.approver_id,
+		approver_id: current.approver_id,
 		error: state.deployment.error,
 		is_loading: state.deployment.is_loading
 	};

--- a/js/containers/ApprovalRO.jsx
+++ b/js/containers/ApprovalRO.jsx
@@ -40,7 +40,7 @@ function getStateDescription(approvalState) {
 	}
 }
 
-const Approval = React.createClass({
+const ApprovalRO = React.createClass({
 
 	getInitialState: function() {
 		return {
@@ -142,19 +142,20 @@ const Approval = React.createClass({
 });
 
 const mapStateToProps = function(state) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
 	const approver = state.deployment.approvers.find(function(val) {
-		if (val.id === state.deployment.approver_id) {
+		if (val.id === current.approver_id) {
 			return val;
 		}
 		return false;
 	});
 
 	return {
-		approval_state: constants.getApprovalState(state.deployment.state, approver),
-		date_requested_nice: state.deployment.data.date_requested_nice,
-		date_approved_nice: state.deployment.data.date_approved_nice,
+		approval_state: constants.getApprovalState(current.state, approver),
+		date_requested_nice: current.date_requested_nice,
+		date_approved_nice: current.date_approved_nice,
 		approver: approver,
-		rejected_reason: state.deployment.rejected_reason,
+		rejected_reason: current.rejected_reason,
 		error: state.deployment.error,
 		is_loading: state.deployment.is_loading
 	};
@@ -174,4 +175,4 @@ const mapDispatchToProps = function(dispatch) {
 	};
 };
 
-module.exports = ReactRedux.connect(mapStateToProps, mapDispatchToProps)(Approval);
+module.exports = ReactRedux.connect(mapStateToProps, mapDispatchToProps)(ApprovalRO);

--- a/js/containers/DeployModal.jsx
+++ b/js/containers/DeployModal.jsx
@@ -233,24 +233,26 @@ const mapStateToProps = function(state, ownProps) {
 		active_step = parseInt(window.location.hash.substring(1), 10);
 	}
 
+	const current = state.deployment.list[state.deployment.current_id] || {};
+
 	return {
 		show: [
 			(!state.git.is_loading && !state.deployment.is_loading),
 			state.git.selected_ref !== "",
-			state.deployment.id !== "",
-			state.deployment.approved
+			state.deployment.current_id !== "",
+			constants.isApproved(current.state)
 		],
 		is_loading: [
 			state.git.is_loading || state.git.is_updating,
 			state.plan.is_loading || state.deployment.is_loading,
 			state.deployment.approval_is_loading,
-			constants.isDeploying(state.deployment.state)
+			constants.isDeploying(current.state)
 		],
 		is_finished: [
 			state.git.selected_ref !== "",
-			state.deployment.id !== "",
-			deployPlanIsOk() && state.deployment.approved,
-			constants.isDeployDone(state.deployment.state)
+			state.deployment.current_id !== "",
+			deployPlanIsOk() && constants.isApproved(current.state),
+			constants.isDeployDone(current.state)
 		],
 		can_edit: constants.canEdit(state),
 		is_open: typeof (ownProps.params.id) !== 'undefined' && ownProps.params.id !== null,
@@ -259,12 +261,12 @@ const mapStateToProps = function(state, ownProps) {
 		sha_is_selected: (state.git.selected_ref !== ""),
 		last_fetched_date: state.git.last_fetched_date,
 		last_fetched_ago: state.git.last_fetched_ago,
-		can_deploy: state.deployment.approved,
-		state: state.deployment.state,
+		can_deploy: (current.state === constants.STATE_APPROVED),
+		state: current.state,
 		active_step: active_step,
 		environment_name: state.environment.name,
 		project_name: state.environment.project_name,
-		deployment_id: state.deployment.id
+		deployment_id: state.deployment.current_id
 	};
 };
 

--- a/js/containers/Deployment.jsx
+++ b/js/containers/Deployment.jsx
@@ -45,7 +45,7 @@ const deployment = React.createClass({
 				</pre>
 				);
 			} else {
-				logOutput = <LoadingBar show />
+				logOutput = <LoadingBar show />;
 			}
 		}
 
@@ -64,11 +64,12 @@ const deployment = React.createClass({
 });
 
 const mapStateToProps = function(state) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
 	return {
-		started: constants.hasDeployStarted(state.deployment.state),
+		started: constants.hasDeployStarted(current.state) || state.deployment.is_queuing,
 		error: state.deployment.error,
 		selected_ref: state.git.selected_ref,
-		deploy_log: state.deployment.logs[state.deployment.id]
+		deploy_log: state.deployment.logs[state.deployment.current_id]
 	};
 };
 

--- a/js/containers/TargetRelease.jsx
+++ b/js/containers/TargetRelease.jsx
@@ -9,6 +9,7 @@ const BuildStatus = require('../components/BuildStatus.jsx');
 const LoadingBar = require('../components/LoadingBar.jsx');
 
 const actions = require('../_actions.js');
+const constants = require('../constants/deployment.js');
 
 const TargetRelease = React.createClass({
 	getInitialState: function() {
@@ -170,16 +171,17 @@ function isDisabled(state) {
 	if (isLoading(state) || state.plan.is_loading) {
 		return true;
 	}
-	if (state.deployment.submitted) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
+	if (constants.isSubmitted(current.state)) {
 		return true;
 	}
-	if (state.deployment.approved) {
+	if (constants.isApproved(current.state)) {
 		return true;
 	}
-	if (state.deployment.rejected) {
+	if (constants.isRejected(current.state)) {
 		return true;
 	}
-	if (state.deployment.queued) {
+	if (constants.isQueued(current.state)) {
 		return true;
 	}
 	return false;

--- a/js/containers/TargetReleaseRO.jsx
+++ b/js/containers/TargetReleaseRO.jsx
@@ -96,19 +96,19 @@ const TargetReleaseRO = React.createClass({
 });
 
 const mapStateToProps = function(state) {
-	if (typeof state.deployment.list[state.deployment.id] === 'undefined') {
+	if (typeof state.deployment.list[state.deployment.current_id] === 'undefined') {
 		return {};
 	}
 
-	const deploy = state.deployment.list[state.deployment.id];
+	const current = state.deployment.list[state.deployment.current_id] || {};
 
 	let ref_type_description = "";
-	if (state.git.list[deploy.ref_type]) {
-		ref_type_description = state.git.list[deploy.ref_type].description;
+	if (state.git.list[current.ref_type]) {
+		ref_type_description = state.git.list[current.ref_type].description;
 	}
 
 	return {
-		deployment: deploy,
+		deployment: current,
 		environment: state.environment.name,
 		ref_type_description: ref_type_description
 	};

--- a/js/containers/buttons/ApproveRequest.jsx
+++ b/js/containers/buttons/ApproveRequest.jsx
@@ -2,10 +2,12 @@ var ReactRedux = require('react-redux');
 
 var actions = require('../../_actions.js');
 var Button = require('../../components/Button.jsx');
+const constants = require('../../constants/deployment.js');
 
 const mapStateToProps = function(state) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
 	return {
-		display: state.user.can_approve && state.deployment.submitted,
+		display: state.user.can_approve && constants.isSubmitted(current.state),
 		disabled: state.deployment.is_loading,
 		style: "btn-success btn-wide",
 		value: "Approve"

--- a/js/containers/buttons/Bypass.jsx
+++ b/js/containers/buttons/Bypass.jsx
@@ -1,23 +1,21 @@
 var ReactRedux = require('react-redux');
 
-var _ = require('underscore');
 var actions = require('../../_actions.js');
 var Button = require('../../components/Button.jsx');
+var constants = require('../../constants/deployment.js');
 
 function canBypass(state) {
-	if (_.isEmpty(state.plan.changes)) {
-		return false;
-	}
 	if (!state.user.can_bypass_approval) {
 		return false;
 	}
-	if (state.deployment.approved) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
+	if (constants.isApproved(current.state)) {
 		return false;
 	}
-	if (state.deployment.rejected) {
+	if (constants.isRejected(current.state)) {
 		return false;
 	}
-	if (state.deployment.submitted) {
+	if (constants.isSubmitted(current.state)) {
 		return false;
 	}
 	return true;

--- a/js/containers/buttons/Deploy.jsx
+++ b/js/containers/buttons/Deploy.jsx
@@ -4,13 +4,14 @@ const ReactRedux = require('react-redux');
 const actions = require('../../_actions.js');
 const constants = require('../../constants/deployment.js');
 
-function canDeploy(state) {
-	if (constants.hasDeployStarted(state.deployment.state)) {
+function canDeploy(deployState) {
+	if (constants.hasDeployStarted(deployState)) {
 		return false;
 	}
-	if (state.deployment.approved) {
+	if (constants.isApproved(deployState)) {
 		return true;
 	}
+
 	return false;
 }
 
@@ -36,9 +37,10 @@ function deployButton(props) {
 }
 
 const mapStateToProps = function(state) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
 	return {
-		queued: state.deployment.queued,
-		display: canDeploy(state)
+		queued: constants.isQueued(current.state) || state.deployment.is_queuing,
+		display: canDeploy(current.state)
 	};
 };
 

--- a/js/containers/buttons/GitUpdate.jsx
+++ b/js/containers/buttons/GitUpdate.jsx
@@ -2,21 +2,23 @@ var ReactRedux = require('react-redux');
 
 var actions = require('../../_actions.js');
 var Button = require('../../components/Button.jsx');
+const constants = require('../../constants/deployment.js');
 
 function isDisabled(state) {
 	if (state.git.is_fetching || state.git.is_updating || state.plan.is_loading) {
 		return true;
 	}
-	if (state.deployment.submitted) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
+	if (constants.isSubmitted(current.state)) {
 		return true;
 	}
-	if (state.deployment.approved) {
+	if (constants.isApproved(current.state)) {
 		return true;
 	}
-	if (state.deployment.rejected) {
+	if (constants.isRejected(current.state)) {
 		return true;
 	}
-	if (state.deployment.queued) {
+	if (constants.isQueued(current.state)) {
 		return true;
 	}
 	return false;

--- a/js/containers/buttons/RejectRequest.jsx
+++ b/js/containers/buttons/RejectRequest.jsx
@@ -2,10 +2,12 @@ var ReactRedux = require('react-redux');
 
 var actions = require('../../_actions.js');
 var Button = require('../../components/Button.jsx');
+const constants = require('../../constants/deployment.js');
 
 const mapStateToProps = function(state) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
 	return {
-		display: state.deployment.submitted,
+		display: constants.isSubmitted(current.state),
 		disabled: state.deployment.is_loading,
 		style: "btn-wide btn-danger",
 		value: "Reject"

--- a/js/containers/buttons/RequestApproval.jsx
+++ b/js/containers/buttons/RequestApproval.jsx
@@ -1,25 +1,24 @@
 var ReactRedux = require('react-redux');
 
-var _ = require('underscore');
 var actions = require('../../_actions.js');
 var Button = require('../../components/Button.jsx');
+const constants = require('../../constants/deployment.js');
 
 function canRequest(state) {
-	if (_.isEmpty(state.plan.changes)) {
+	const current = state.deployment.list[state.deployment.current_id] || {};
+	if (!current.approver_id) {
 		return false;
 	}
-	if (!state.deployment.approver_id) {
+	if (constants.isApproved(current.state)) {
 		return false;
 	}
-	if (state.deployment.approved) {
+	if (constants.isRejected(current.state)) {
 		return false;
 	}
-	if (state.deployment.rejected) {
+	if (constants.isSubmitted(current.state)) {
 		return false;
 	}
-	if (state.deployment.submitted) {
-		return false;
-	}
+
 	return true;
 }
 

--- a/js/containers/buttons/SaveDeployPlan.jsx
+++ b/js/containers/buttons/SaveDeployPlan.jsx
@@ -5,7 +5,7 @@ var Button = require('../../components/Button.jsx');
 
 const mapStateToProps = function(state) {
 	return {
-		display: state.deployment.id === "",
+		display: state.deployment.current_id === "",
 		disabled: state.plan.is_loading || state.deployment.is_creating,
 		style: "btn-wide btn-primary",
 		value: "Continue",


### PR DESCRIPTION
This change removes state duplication and uses the state.deployment.list
as the canonical source of all deploy data