### PR TITLE
Cache the current user

### DIFF
--- a/code/SS_Datetimezone.php
+++ b/code/SS_Datetimezone.php
@@ -5,6 +5,12 @@
  * Adds customisable timezones to the nice method on {@link SS_Datetime}.
  */
 class SS_Datetimezone extends SS_Datetime {
+
+	/**
+	 * @var \Member[]
+	 */
+	protected static $_cache_members = [];
+
 	/**
 	* Returns the date in the raw SQL-format specific to a given timezone passed from the Member class, e.g. “2006-01-18 16:32:04”
 	*/
@@ -12,11 +18,28 @@ class SS_Datetimezone extends SS_Datetime {
 		if($this->value){
 			$date = new DateTime($this->value);
 			//if the current user has set a timezone that is not the default then use that
-			$member = Member::currentUser();
+			$member = $this->getCurrentCachedUser();
 			if ($member && $member->exists() && $member->Timezone && $member->Timezone != date_default_timezone_get()) {
-				$date->setTimezone(new DateTimeZone($member->Timezone));    
+				$date->setTimezone(new DateTimeZone($member->Timezone));
 			}
 			return $date->Format($format);
 		}
+	}
+
+	/**
+	 * Format can be called a lot of time in tight loops, so we cache the current user
+	 * per request
+	 *
+	 * @return \Member|null
+	 */
+	protected function getCurrentCachedUser() {
+		$memberID = \Member::currentUserID();
+		if(!$memberID) {
+			return null;
+		}
+		if(!isset(self::$_cache_members[$memberID])) {
+			self::$_cache_members[$memberID] = Member::get()->byId($memberID);
+		}
+		return self::$_cache_members[$memberID];
 	}
 }


### PR DESCRIPTION
Member::currentUser() fetches the user from the database on each call. Cache it per request in a memory cache.

This change is using a $_cache_ array, so that tests don't fail as easily.