### PR TITLE
Radio input name should be the same as what you give it

### DIFF
--- a/js/components/Radio.jsx
+++ b/js/components/Radio.jsx
@@ -1,7 +1,6 @@
 var React = require("react");
 
 var Radio = function (props) {
-
 	var classes = "radio";
 	if (props.disabled === true) {
 		classes += " disabled";
@@ -12,7 +11,7 @@ var Radio = function (props) {
 				<input
 					onChange={props.onClick}
 					type="radio"
-					name={props.name + props.id}
+					name={props.name}
 					id={props.name + props.id}
 					value={props.id}
 					checked={props.checked}


### PR DESCRIPTION
So that you can group radio inputs together, e.g.

	<input type="radio" name="whatisit" value="yes" />
	<input type="radio" name="whatisit" value="no" />

Currently it does:

	<input type="radio" name="whatisityes" value="yes" />
	<input type="radio" name="whatisitno" value="no" />