### PR TITLE
fix direct URL opening of a deployment doesn't always show plan

### DIFF
--- a/js/containers/DeployModal.jsx
+++ b/js/containers/DeployModal.jsx
@@ -172,7 +172,7 @@ const mapStateToProps = function(state, ownProps) {
 
 	const current = state.deployment.list[state.deployment.current_id] || {};
 
-	const showPlan = state.git.selected_ref !== "" && (state.plan.changes);
+	const showPlan = state.git.selected_ref !== "" && (typeof state.plan.changes === "object");
 	const showApproval = state.deployment.current_id !== "";
 
 	return {

--- a/js/reducers/plan.js
+++ b/js/reducers/plan.js
@@ -23,7 +23,6 @@ module.exports = function plan(state, action) {
 		case actions.START_DEPLOYMENT_GET:
 		case actions.SET_REVISION:
 		case actions.SUCCEED_REPO_UPDATE:
-		case actions.SUCCEED_REVISIONS_GET:
 		case actions.TOGGLE_OPTION:
 			return initialState;
 


### PR DESCRIPTION
There is a race condition between fetching deployment and git data. When the
fetching of git is done, the plan reducers zeroes out the plan data. This
causes issues when the deploy data is loaded before the git data.

For the user this shows as the deployment loading fine in the UI and then
the plan and approval sections just disappears.