### PR TITLE
add a deleted state for deployments for ui updates and auditing

### DIFF
--- a/code/control/DeployDispatcher.php
+++ b/code/control/DeployDispatcher.php
@@ -122,11 +122,16 @@ class DeployDispatcher extends Dispatcher {
 			return $errorResponse;
 		}
 
-		$id = $deployment->ID;
-		$deployment->delete();
+		try {
+			$deployment->getMachine()->apply(\DNDeployment::TR_DELETE);
+		} catch (\Exception $e) {
+			return $this->getAPIResponse([
+				'message' => $e->getMessage()
+			], 400);
+		}
 
 		return $this->getAPIResponse([
-			'id' => $id,
+			'deployment' => $this->formatter->getDeploymentData($deployment),
 			'message' => 'Deployment has been deleted'
 		], 201);
 	}

--- a/code/model/StateMachineFactory.php
+++ b/code/model/StateMachineFactory.php
@@ -22,6 +22,7 @@ class StateMachineFactory extends Object {
 				DNDeployment::STATE_ABORTING => ['type' => StateInterface::TYPE_NORMAL],
 				DNDeployment::STATE_COMPLETED => ['type' => StateInterface::TYPE_FINAL],
 				DNDeployment::STATE_FAILED => ['type' => StateInterface::TYPE_FINAL],
+				DNDeployment::STATE_DELETED => ['type' => StateInterface::TYPE_FINAL],
 			],
 			'transitions' => [
 				DNDeployment::TR_NEW => ['from' => [DNDeployment::STATE_SUBMITTED], 'to' => DNDeployment::STATE_NEW],
@@ -71,6 +72,16 @@ class StateMachineFactory extends Object {
 						DNDeployment::STATE_ABORTING
 					],
 					'to' => DNDeployment::STATE_FAILED
+				],
+				DNDeployment::TR_DELETE  => [
+					'from' => [
+						DNDeployment::STATE_NEW,
+						DNDeployment::STATE_SUBMITTED,
+						DNDeployment::STATE_INVALID,
+						DNDeployment::STATE_APPROVED,
+						DNDeployment::STATE_REJECTED,
+					],
+					'to' => DNDeployment::STATE_DELETED
 				],
 			]
 		]);

--- a/code/model/jobs/DNDeployment.php
+++ b/code/model/jobs/DNDeployment.php
@@ -27,6 +27,9 @@ class DNDeployment extends DataObject implements Finite\StatefulInterface, HasSt
 	const STATE_ABORTING = 'Aborting';
 	const STATE_COMPLETED = 'Completed';
 	const STATE_FAILED = 'Failed';
+	// Deleted is used as 'soft-delete' which will in all regards keep the record in the DB
+	// but not display it in the UI. This is for auditing and also for UI history updates
+	const STATE_DELETED = 'Deleted';
 
 	const TR_NEW = 'new';
 	const TR_SUBMIT = 'submit';
@@ -38,6 +41,7 @@ class DNDeployment extends DataObject implements Finite\StatefulInterface, HasSt
 	const TR_ABORT = 'abort';
 	const TR_COMPLETE = 'complete';
 	const TR_FAIL = 'fail';
+	const TR_DELETE = 'delete';
 
 	/**
 	 * @var array
@@ -51,7 +55,7 @@ class DNDeployment extends DataObject implements Finite\StatefulInterface, HasSt
 		"Branch" => "Varchar(255)",
 		// is it a branch, tag etc, see GitDispatcher REF_TYPE_* constants
 		"RefType" => "Int",
-		"State" => "Enum('New, Submitted, Invalid, Approved, Rejected, Queued, Deploying, Aborting, Completed, Failed', 'New')",
+		"State" => "Enum('New, Submitted, Invalid, Approved, Rejected, Queued, Deploying, Aborting, Completed, Failed, Deleted', 'New')",
 		// JSON serialised DeploymentStrategy.
 		"Strategy" => "Text",
 		"Title" => "Varchar(255)",

--- a/js/constants/deployment.js
+++ b/js/constants/deployment.js
@@ -9,6 +9,7 @@ export const STATE_DEPLOYING = 'Deploying';
 export const STATE_ABORTING = 'Aborting';
 export const STATE_COMPLETED = 'Completed';
 export const STATE_FAILED = 'Failed';
+export const STATE_DELETED = 'Deleted';
 
 // These constants are a subset of the deploynaut states
 // this is because an approval can be bypassed and also

--- a/js/containers/UpcomingDeployments.jsx
+++ b/js/containers/UpcomingDeployments.jsx
@@ -85,6 +85,7 @@ const mapStateToProps = function(state) {
 				case deployStates.STATE_COMPLETED:
 				case deployStates.STATE_INVALID:
 				case deployStates.STATE_FAILED:
+				case deployStates.STATE_DELETED:
 					return false;
 				default:
 					return true;

--- a/js/reducers/deployment.js
+++ b/js/reducers/deployment.js
@@ -173,8 +173,9 @@ module.exports = function deployment(state, action) {
 			});
 		}
 		case actions.SUCCEED_DEPLOYMENT_DELETE: {
+			// get current list
 			const newList = _.assign({}, state.list);
-			delete newList[action.data.id];
+			newList[action.data.deployment.id] = action.data.deployment;
 
 			return _.assign({}, state, {
 				error: null,


### PR DESCRIPTION
By using a soft delete approach we still keep the data for auditing
and can send 'real time' updates to the UI about which deployment(s)
was deleted for other users having the same page opened.