### PR TITLE
Cleanup deployment status area

### DIFF
--- a/js/containers/DeploymentStatusBar.jsx
+++ b/js/containers/DeploymentStatusBar.jsx
@@ -60,7 +60,7 @@ function DeploymentStatusBar(props) {
 	const timeInformation = getTimeInformation(deployState, props);
 
 	return (
-		<div className="deployment-status-bar fade-in">
+		<div className="deployment-status-bar fade-in clearfix">
 			<div className={"deployment-status-icon " + deployState}>
 				<i className={"fa " + headerIcon} aria-hidden="true" />
 			</div>
@@ -77,9 +77,9 @@ function DeploymentStatusBar(props) {
 						>close this screen</a> {descriptionText}
 					</div>
 				</div>
-				<div className="pull-right">
-					<AbortButton />
-				</div>
+			</div>
+			<div className="abort-action pull-right">
+				<AbortButton />
 			</div>
 		</div>
 	);

--- a/sass/components/_deployment-status-bar.sass
+++ b/sass/components/_deployment-status-bar.sass
@@ -9,8 +9,10 @@
 		font-size: 50px
 		line-height: 80px
 		padding: 0 20px
-		float: left
+		display: inline-block
 		color: $platform-blue
+		@media (max-width: $screen-md)
+			display: none
 
 		&.Aborting
 			color: $status-aborting
@@ -28,17 +30,18 @@
 			color: $status-rejected
 
 	.deployment-status-text-parent
-		position: relative
 		min-height: 80px
-		padding: 0 10px 0 100px
+		padding: 20px
+		display: inline-block
 
-		.deployment-status-text-child
-			position: absolute
-			top: 50%
-			margin-top: -20px
-
-			.deployment-status-header
-				font-size: $font-size-large
-
-			.deployment-status-close-notice
-
+		.deployment-status-header
+			font-size: $font-size-large
+	.abort-action
+		padding: 20px 20px 0 0
+		button
+			margin-bottom: 0
+		@media (max-width: $screen-lg)
+			width: 100%
+			padding: 0
+			button
+				width: 100%

--- a/static/style.css
+++ b/static/style.css
@@ -11690,8 +11690,11 @@ select.selectize-control,
     font-size: 50px;
     line-height: 80px;
     padding: 0 20px;
-    float: left;
+    display: inline-block;
     color: #3aaef9; }
+    @media (max-width: 992px) {
+      .deployment-status-bar .deployment-status-icon {
+        display: none; } }
     .deployment-status-bar .deployment-status-icon.Aborting {
       color: #f0ad4e; }
     .deployment-status-bar .deployment-status-icon.Submitted {
@@ -11707,15 +11710,21 @@ select.selectize-control,
     .deployment-status-bar .deployment-status-icon.Rejected {
       color: #d9534f; }
   .deployment-status-bar .deployment-status-text-parent {
-    position: relative;
     min-height: 80px;
-    padding: 0 10px 0 100px; }
-    .deployment-status-bar .deployment-status-text-parent .deployment-status-text-child {
-      position: absolute;
-      top: 50%;
-      margin-top: -20px; }
-      .deployment-status-bar .deployment-status-text-parent .deployment-status-text-child .deployment-status-header {
-        font-size: 16px; }
+    padding: 20px;
+    display: inline-block; }
+    .deployment-status-bar .deployment-status-text-parent .deployment-status-header {
+      font-size: 16px; }
+  .deployment-status-bar .abort-action {
+    padding: 20px 20px 0 0; }
+    .deployment-status-bar .abort-action button {
+      margin-bottom: 0; }
+    @media (max-width: 1200px) {
+      .deployment-status-bar .abort-action {
+        width: 100%;
+        padding: 0; }
+        .deployment-status-bar .abort-action button {
+          width: 100%; } }
 
 .deploy-plan .summary_title {
   margin: 10px 0 20px;


### PR DESCRIPTION
 - Make abort button align to right with correct spacing
 - Make abort button full width when it can't fit alongside status text
 - Remove use of absolute position
 - Clear status bar properly on smaller widths
 - Hide icon on very small widths, it doesn't fit