### PR TITLE
add checkbox for resampled dir to RF envs

### DIFF
--- a/code/model/jobs/DNDataTransfer.php
+++ b/code/model/jobs/DNDataTransfer.php
@@ -40,6 +40,7 @@ class DNDataTransfer extends DataObject {
 		"Direction" => "Enum('get, push', 'get')",
 		"Mode" => "Enum('all, assets, db', '')",
 		"Origin" => "Enum('EnvironmentTransfer,ManualUpload', 'EnvironmentTransfer')",
+		"IncludeResampled" => "Boolean",
 	);
 
 	private static $has_one = array(
@@ -60,6 +61,7 @@ class DNDataTransfer extends DataObject {
 		'Environment.Name' => 'Environment',
 		'Status' => 'Status',
 		'Origin' => 'Origin',
+		'IncludeResampled.Nice' => 'Included Resampled?',
 	);
 
 	private static $searchable_fields = array(
@@ -166,7 +168,8 @@ class DNDataTransfer extends DataObject {
 		$args = array(
 			'dataTransferID' => $this->ID,
 			'logfile' => $this->logfile(),
-			'backupBeforePush' => $this->backupBeforePush
+			'backupBeforePush' => $this->backupBeforePush,
+			'includeResampled' => $this->IncludeResampled,
 		);
 
 		if(!$this->AuthorID) {


### PR DESCRIPTION
This adds the checkbox into the dashboard (if it's a Rainforest Environment) to include the resampled directory in an assets snapshot