### PR TITLE
MINOR/add logged in links to DNRoot template

### DIFF
--- a/code/control/DNRoot.php
+++ b/code/control/DNRoot.php
@@ -141,6 +141,11 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	/**
 	 * @var array
 	 */
+	private static $logged_in_links = [];
+
+	/**
+	 * @var array
+	 */
 	private static $platform_specific_strings = [];
 
 	/**
@@ -199,6 +204,16 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 	}
 
 	/**
+	 * @return ArrayList
+	 */
+	public static function get_logged_in_links() {
+		$loggedInLinks = self::config()->logged_in_links;
+		if ($loggedInLinks) {
+			return new ArrayList($loggedInLinks);
+		}
+	}
+
+	/**
 	 * @return array
 	 */
 	public static function get_template_global_variables() {
@@ -206,7 +221,8 @@ class DNRoot extends Controller implements PermissionProvider, TemplateGlobalPro
 			'RedisUnavailable' => 'RedisUnavailable',
 			'RedisWorkersCount' => 'RedisWorkersCount',
 			'SidebarLinks' => 'SidebarLinks',
-			"SupportLinks" => 'get_support_links'
+			'SupportLinks' => 'get_support_links',
+			'LoggedInLinks' => 'get_logged_in_links',
 		];
 	}
 

--- a/templates/Includes/Nav.ss
+++ b/templates/Includes/Nav.ss
@@ -48,10 +48,18 @@
 	<% end_if %>
 <% end_if %>
 
-<% if $SupportLinks %>
+<% if $SupportLinks || $LoggedInLinks %>
 	<li class="nav-main-heading">Support</li>
-
-	<% loop $SupportLinks %>
-		<li><a href="$URL"><span class="plat-icon $IconClass"></span>$Title</a></li>
-	<% end_loop %>
+	<% if $SupportLinks %>
+		<% loop $SupportLinks %>
+			<li><a href="$URL"><span class="plat-icon $IconClass"></span>$Title</a></li>
+		<% end_loop %>
+	<% end_if %>
+	<% if $LoggedInLinks %>
+		<% if $CurrentMember %>
+			<% loop $LoggedInLinks %>
+				<li><a href="$URL"><span class="plat-icon $IconClass"></span>$Title</a></li>
+			<% end_loop %>
+		<% end_if %>
+	<% end_if %>
 <% end_if %>


### PR DESCRIPTION
This allows us to define links in the "Support" section that are only visible once logged in - combines with [this commit](https://github.com/silverstripeltd/platform-dashboard/pull/355) to hide the Announcements tab until the user is logged in.